### PR TITLE
Improve docker-compose helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,17 +128,20 @@ file for development. It sets the following up:
 
 - Makes it straightforward to run tests
 
-You may use the provided `docker/compose-up.sh` and `docker/compose-down.sh`
-helper scripts to stand up and wind down the stack.
+Additionally, we suggest you use the provided `docker/compose.py` helper script
+to stand up and wind down the stack.
 
 ```
 cd docker
 
 # bring the stack up
-./compose-up.sh
+./compose.py up
 
 # shut it down
-./compose-down.sh
+./compose.py down
+
+# restart services (for example the ckan-web service)
+./compose.py restart ckan-web
 ```
 
 After starting the stack, the ckan web interface is available (after a few

--- a/docker/compose-down.sh
+++ b/docker/compose-down.sh
@@ -1,4 +1,0 @@
-docker-compose \
-    --project-name=emc-dcpr \
-    --file docker-compose.dev.yml \
-    down

--- a/docker/compose-up.sh
+++ b/docker/compose-up.sh
@@ -1,4 +1,0 @@
-docker-compose \
-    --project-name=emc-dcpr \
-    --file docker-compose.dev.yml \
-    up --detach

--- a/docker/compose.py
+++ b/docker/compose.py
@@ -1,0 +1,112 @@
+#! /usr/bin/env python3
+"""Manage docker-compose"""
+
+import argparse
+import logging
+import os
+import shlex
+import sys
+import typing
+from subprocess import check_output
+
+logger = logging.getLogger(__name__)
+
+_FALLBACK_GIT_BRANCH = "main"
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--verbose", action="store_true")
+    subparsers = parser.add_subparsers()
+    compose_up_parser = subparsers.add_parser("up")
+    compose_up_parser.set_defaults(func=run_compose_up)
+    compose_down_parser = subparsers.add_parser("down")
+    compose_down_parser.set_defaults(func=run_compose_down)
+    compose_restart_parser = subparsers.add_parser("restart")
+    compose_restart_parser.set_defaults(func=run_compose_restart)
+    compose_restart_parser.add_argument("service", nargs="+")
+    args = parser.parse_args()
+    logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO)
+    args.func(args)
+
+
+def run_compose_up(args):
+    image_tag = _get_image_tag_name()
+    if image_tag is not None:
+        exec_env = _get_exec_environment(image_tag)
+        logger.info(f"Using {image_tag!r} as the tag for the CKAN image...")
+        _run_docker_compose("up --detach", exec_env)
+    else:
+        raise SystemExit(
+            f"There is no docker image for the current git branch yet, and neither "
+            f"for the {_FALLBACK_GIT_BRANCH!r} branch - Please build the image "
+            f"first. Aborting..."
+        )
+
+
+def run_compose_down(args):
+    image_tag = _get_image_tag_name()
+    if image_tag is not None:
+        exec_env = _get_exec_environment(image_tag)
+    else:
+        exec_env = os.environ.copy()
+    _run_docker_compose("down", exec_env)
+
+
+def run_compose_restart(args):
+    _run_docker_compose(f"restart {' '.join(args.service)}")
+
+
+def _get_compose_command(fragment: str) -> str:
+    template = (
+        "docker-compose " "--project-name={project} " "--file={file_} " "{fragment}"
+    )
+    return template.format(
+        project="emc-dcpr", file_="docker-compose.dev.yml", fragment=fragment
+    )
+
+
+def _get_image_tag_name() -> typing.Optional[str]:
+    current_git_branch = check_output(
+        shlex.split("git rev-parse --abbrev-ref HEAD"), text=True
+    ).strip("\n")
+    image_name = "kartoza/ckanext-dalrrd-emc-dcpr"
+    existing_image_tags = check_output(
+        shlex.split(f"docker images {image_name} --format '{{{{.Tag}}}}'"), text=True
+    ).split("\n")
+    if current_git_branch in existing_image_tags:
+        logger.debug("The current branch already has a built tag, lets use that")
+        result = current_git_branch
+    elif "main" in existing_image_tags:
+        logger.debug(
+            f"The current branch does not have a built tag yet, lets use the "
+            f"{_FALLBACK_GIT_BRANCH!r} image tag"
+        )
+        result = _FALLBACK_GIT_BRANCH
+    else:
+        result = None
+    return result
+
+
+def _get_exec_environment(image_tag: str) -> typing.Dict[str, str]:
+    env = os.environ.copy()
+    env["CKAN_IMAGE_TAG"] = image_tag
+    return env
+
+
+def _run_docker_compose(
+    command_fragment: str, environment: typing.Optional[typing.Dict[str, str]] = None
+):
+    env = environment or os.environ.copy()
+    command = _get_compose_command(command_fragment)
+    logger.debug(
+        f"About to replace the current process with the one that results from running "
+        f"{command!r} with an environment of {env}"
+    )
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os.execvpe("docker-compose", shlex.split(command), env)
+
+
+if __name__ == "__main__":
+    main()

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -1,6 +1,25 @@
+# NOTE: this file expects to find the $CKAN_IMAGE_TAG variable in its environment
+
 version: "3.8"
 
 services:
+
+  ckan-web:
+    image: kartoza/ckanext-dalrrd-emc-dcpr:${CKAN_IMAGE_TAG}
+    volumes:
+      - type: bind
+        source: $PWD/..
+        target: /home/appuser/app
+      - type: bind
+        source: $PWD/ckan-dev-settings.ini
+        target: /home/appuser/ckan.ini
+      - type: bind
+        source: $PWD/who.ini
+        target: /home/appuser/who.ini
+      - ckan-storage:/home/appuser/data
+    ports:
+      - target: 5000
+        published: 5000
 
   ckan-db:
     image: postgis/postgis:13-3.1
@@ -25,23 +44,6 @@ services:
         published: 55433
     volumes:
       - datastore-db-data:/var/lib/postgresql/data
-
-  ckan-web:
-    image: kartoza/ckanext-dalrrd-emc-dcpr:add-dockerfile
-    volumes:
-      - type: bind
-        source: $PWD/..
-        target: /home/appuser/app
-      - type: bind
-        source: $PWD/ckan-dev-settings.ini
-        target: /home/appuser/ckan.ini
-      - type: bind
-        source: $PWD/who.ini
-        target: /home/appuser/who.ini
-      - ckan-storage:/home/appuser/data
-    ports:
-      - target: 5000
-        published: 5000
 
   # NOTE: ckan/solr uses solr v 6.6 which is pretty old (EOL even), but as of CKAN 2.9.x it is
   # unfortunately still the most recent supported version. More info:


### PR DESCRIPTION
This PR improves the docker-compose helper scripts used for development.

The `compose-up.sh` and `compose-down.sh` scripts are replaced by the `compose.py` Python script. This new script is able to figure out the correct docker image tag to be used when standing up the docker-compose stack.

fixes #21