### PR TITLE
publish built images to dockerhub

### DIFF
--- a/.github/workflows/handle-pr-artifacts.yml
+++ b/.github/workflows/handle-pr-artifacts.yml
@@ -1,0 +1,55 @@
+name: Handle PR artifacts
+
+on:
+  workflow_run:
+    workflows:
+      - "Receive PR"
+    types:
+      - completed
+
+jobs:
+  push-image:
+    runs-on: ubuntu-20.04
+    if: >
+      ${{ github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Download artifact
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{github.event.workflow_run.id}},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: matchArtifact.id,
+              archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
+
+      - name: Unzip downloaded artifact
+        run: unzip pr.zip
+
+      - name: load built docker images contained in artifact
+        run: docker load --input ./pr/built_docker_image.tar.gz
+
+      - name: Login to dockerhub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: publish to dockerhub
+        run: |
+          images_to_push=$(docker images kartoza/ckanext-dalrrd-emc-dcpr --format "{{ .Repository }}:{{ .Tag }}")
+          for image in images_to_push
+              do docker push $image
+          done

--- a/.github/workflows/local-ci.yml
+++ b/.github/workflows/local-ci.yml
@@ -1,6 +1,5 @@
 on:
   - push
-  - pull_request
 
 jobs:
   ci:

--- a/.github/workflows/receive-pr.yml
+++ b/.github/workflows/receive-pr.yml
@@ -1,0 +1,82 @@
+# Github does not allow workflows initiated by PRs that come from a fork to
+# have access to secrets or to have `write` access to the repo. As such, we
+# employ the strategy described in:
+#
+# https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+#
+# which basically uses two workflows:
+#
+# - First workflow (this one) is triggered by the PR and proceeds to check the
+# code and build whatever artifacts (in this repo we are building docker images).
+# Since this first workflow is (potentially) initiated by forks submitting a PR,
+# it will most likely not have access to the repo secrets. This means, for example,
+# that it cannot login to dockerhub to push a built docker image (as credentials
+# are stored as secrets). This workflow builds the image and then stores it as an
+# artifact;
+#
+# - Second workflow (handle-pr-artifacts.yml) is triggered by the first one's successful
+# completion. This workflow does have access to secrets. As such, it can retrieve the
+# built artifact and push it
+
+name: Receive PR
+
+on:
+  - pull_request
+
+jobs:
+  ci:
+    name: Continuous Integration
+    runs-on: ubuntu-20.04
+    env:
+      IMAGE_NAME: ${{ github.repository }}
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v2
+
+      - name: Check code formatting with black
+        uses: psf/black@stable
+        with:
+          options: "--check --verbose"
+
+      - name: Setup docker buildx
+        uses: docker/setup-buildx-action@v1.6.0
+
+      - name: Get current git commit hash
+        uses: priyesh2609/sha-trim-action@v1.1.1
+
+      - name: Get current git branch name
+        uses: EthanSK/git-branch-name-action@v1
+
+      - name: Build docker image
+        working-directory: ./docker
+        shell: bash
+        env:
+          DEFAULT_BRANCH: main
+        run: |
+          docker pull $IMAGE_NAME:$DEFAULT_BRANCH || true
+          docker pull $IMAGE_NAME:$GIT_BRANCH_NAME || true
+          docker image build \
+            --tag "$IMAGE_NAME:$GIT_BRANCH_NAME" \
+            --tag "$IMAGE_NAME:$TRIMMED_SHA" \
+            --label git-commit=$TRIMMED_SHA \
+            --label git-branch=$GIT_BRANCH_NAME \
+            --build-arg "BUILDKIT_INLINE_CACHE=1" \
+            --build-arg "GIT_COMMIT=$TRIMMED_SHA" \
+            --cache-from=$IMAGE_NAME:$DEFAULT_BRANCH \
+            --cache-from=$IMAGE_NAME:$GIT_BRANCH_NAME \
+            ..
+
+      - name: Save PR number
+        run: |
+          mkdir -p ./pr
+          echo ${{ github.event.number }} > ./pr/NR
+
+      - name: Save docker image and tags
+        run: |
+          docker save "$IMAGE_NAME:$GIT_BRANCH_NAME" "$IMAGE_NAME:$TRIMMED_SHA" | gzip > ./pr/built_docker_image.tar.gz
+
+      - name: Persist artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: pr
+          path: pr/


### PR DESCRIPTION
This PR uses the recently created [dockerhub repo](https://hub.docker.com/r/kartoza/ckanext-dalrrd-emc-dcpr) adds additional github workflows for handling the PR and then pushing images to docker hub

Implementation is influenced by

https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

fixes #25