### PR TITLE
Add shields to README

### DIFF
--- a/.github/workflows/local-ci.yml
+++ b/.github/workflows/local-ci.yml
@@ -1,3 +1,4 @@
+name: Local CI
 on:
   - push
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # ckanext-dalrrd-emc-dcpr
 
+![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/kartoza/ckanext-dalrrd-emc-dcpr/Local%20CI/main)
+![Docker Image Version (latest by date)](https://img.shields.io/docker/v/kartoza/ckanext-dalrrd-emc-dcpr)
+
 This is a [ckan](https://ckan.org) extension that implements the Electronic
 Metadata Catalog for South Africa's Department of Agriculture, Land Reform
 and Rural Development (DALRRD). It also contains additional utilities,


### PR DESCRIPTION
This PR adds a couple of shields to the README, just to serve as a skeleton. We can add more later on with code coverage, etc.

fixes #29 