### PR TITLE
Fix bug in ci workflows

### DIFF
--- a/.github/workflows/local-ci.yml
+++ b/.github/workflows/local-ci.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Run common CI
         uses: ./.github/actions/action-common-ci
         with:
-          image-name: ${{ IMAGE_NAME }}
+          image-name: kartoza/ckanext-dalrrd-emc-dcpr
 
       - name: Login to dockerhub
         uses: docker/login-action@v1

--- a/.github/workflows/receive-pr.yml
+++ b/.github/workflows/receive-pr.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Run common CI
         uses: ./.github/actions/action-common-ci
         with:
-          image-name: ${{ github.repository }}
+          image-name: kartoza/ckanext-dalrrd-emc-dcpr
 
       - name: Save PR number
         run: |


### PR DESCRIPTION
This PR fixes a bug in the `local-ci` workflow that was caising it to fail due to an undefined variable