### PR TITLE
Add cli commands for creating SASDI themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,13 @@ guide to install CKAN, then follow the below steps:
   ckan spatial extents
   ```
 
+- Create bootstrap items
+
+  ```
+  ckan dalrrd-emc-dcpr bootstrap create-sasdi-themes
+  ckan dalrrd-emc-dcpr bootstrap create-organizations
+  ```
+
 
 
 
@@ -258,12 +265,19 @@ docker exec -ti emc-dcpr_ckan-web_1 poetry run ckan spatial initdb
 
 #### Note
 
-The spatial extension documentation seems to be outdated when it comes to running its custom CKAN CLI commands. Instead
+The spatial extension documentation seems to be outdated when it comes to
+running its custom CKAN CLI commands. Instead
 of the older `paster`-based incantation, they should rather be ran like:
 
 ```sh
 poetry run ckan spatial <command>
 ```
+
+
+### Bootstrap the system
+
+Create the default items required by the EMC/DCPR system by running the
+bootstrap commands as described in the [Operations section](#operations)
 
 
 ### Using CKAN commands

--- a/ckanext/dalrrd_emc_dcpr/commands.py
+++ b/ckanext/dalrrd_emc_dcpr/commands.py
@@ -87,7 +87,7 @@ def create_sasdi_themes():
     click.secho("Done!", fg="green")
 
 
-@bootstrap.command(short_help="Example bootstrap command")
+@bootstrap.command()
 def delete_sasdi_themes():
     """Delete SASDI themes
 
@@ -128,3 +128,46 @@ def delete_sasdi_themes():
             fg="yellow",
         )
     click.secho(f"Done!", fg="green")
+
+
+@bootstrap.command()
+def create_organizations():
+    """Create main SASDI organizations
+
+    This command creates the main SASDI organizations: NSIF, CSI.
+
+    It can safely be called multiple times - it will only ever create the
+    organizations once, if they do not exist already.
+
+    """
+    organizations = [
+        {
+            "name": "NSIF",
+            "description": "This is the NSIF organization",
+            "image": None,
+            "custom_fields": [],
+            "members": [
+                {
+                    "id": None,
+                    "role": "admin",
+                }
+            ],
+        },
+    ]
+    for org_details in organizations:
+        try:
+            current_org = toolkit.get_action("organization_show")(
+                context={},
+                data_dict={
+                    "id": org_details["name"],
+                    "include_datasets": False,
+                    "include_dataset_count": False,
+                    "include_extras": True,
+                    "include_users": True,
+                    "include_groups": True,
+                    "include_tags": True,
+                },
+            )
+            click.echo(f"current_org: {current_org}")
+        except toolkit.ObjectNotFound:
+            click.echo(f"Could not find org {org_details['name']!r}")

--- a/ckanext/dalrrd_emc_dcpr/commands.py
+++ b/ckanext/dalrrd_emc_dcpr/commands.py
@@ -6,6 +6,8 @@ import click
 
 from ckan.plugins import toolkit
 
+from .constants import SASDI_THEMES_VOCABULARY_NAME
+
 logger = logging.getLogger(__name__)
 
 
@@ -36,27 +38,29 @@ def create_sasdi_themes():
 
     """
 
-    vocabulary_name = "sasdi_themes"
     click.secho(
-        f"Creating {vocabulary_name!r} CKAN tag vocabulary and adding configured SASDI "
-        f"themes to it..."
+        f"Creating {SASDI_THEMES_VOCABULARY_NAME!r} CKAN tag vocabulary and adding "
+        f"configured SASDI themes to it..."
     )
 
     user = toolkit.get_action("get_site_user")({"ignore_auth": True}, {})
     context = {"user": user["name"]}
     vocab_list = toolkit.get_action("vocabulary_list")(context)
     for voc in vocab_list:
-        if voc["name"] == vocabulary_name:
+        if voc["name"] == SASDI_THEMES_VOCABULARY_NAME:
             vocabulary = voc
             click.secho(
-                f"Vocabulary {vocabulary_name!r} already exists, skipping creation...",
+                (
+                    f"Vocabulary {SASDI_THEMES_VOCABULARY_NAME!r} already exists, "
+                    f"skipping creation..."
+                ),
                 fg="yellow",
             )
             break
     else:
-        click.echo(f"Creating vocabulary {vocabulary_name!r}...")
+        click.echo(f"Creating vocabulary {SASDI_THEMES_VOCABULARY_NAME!r}...")
         vocabulary = toolkit.get_action("vocabulary_create")(
-            context, {"name": vocabulary_name}
+            context, {"name": SASDI_THEMES_VOCABULARY_NAME}
         )
 
     for theme_name in toolkit.config.get(
@@ -66,14 +70,18 @@ def create_sasdi_themes():
             already_exists = theme_name in [tag["name"] for tag in vocabulary["tags"]]
             if not already_exists:
                 click.echo(
-                    f"Adding tag {theme_name!r} to vocabulary {vocabulary_name!r}..."
+                    f"Adding tag {theme_name!r} to "
+                    f"vocabulary {SASDI_THEMES_VOCABULARY_NAME!r}..."
                 )
                 toolkit.get_action("tag_create")(
                     context, {"name": theme_name, "vocabulary_id": vocabulary["id"]}
                 )
             else:
                 click.secho(
-                    f"Tag {theme_name!r} is already part of the {vocabulary_name!r} vocabulary, skipping...",
+                    (
+                        f"Tag {theme_name!r} is already part of the "
+                        f"{SASDI_THEMES_VOCABULARY_NAME!r} vocabulary, skipping..."
+                    ),
                     fg="yellow",
                 )
     click.secho("Done!", fg="green")
@@ -93,24 +101,30 @@ def delete_sasdi_themes():
 
     user = toolkit.get_action("get_site_user")({"ignore_auth": True}, {})
     context = {"user": user["name"]}
-    vocabulary_name = "sasdi_themes"
     vocabulary_list = toolkit.get_action("vocabulary_list")(context)
-    if vocabulary_name in [voc["name"] for voc in vocabulary_list]:
+    if SASDI_THEMES_VOCABULARY_NAME in [voc["name"] for voc in vocabulary_list]:
         click.secho(
-            f"Deleting {vocabulary_name!r} CKAN tag vocabulary and respective tags... "
+            f"Deleting {SASDI_THEMES_VOCABULARY_NAME!r} CKAN tag vocabulary and "
+            f"respective tags... "
         )
         existing_tags = toolkit.get_action("tag_list")(
-            context, {"vocabulary_id": vocabulary_name}
+            context, {"vocabulary_id": SASDI_THEMES_VOCABULARY_NAME}
         )
         for tag_name in existing_tags:
             click.secho(f"Deleting tag {tag_name!r}...")
             toolkit.get_action("tag_delete")(
-                context, {"id": tag_name, "vocabulary_id": vocabulary_name}
+                context, {"id": tag_name, "vocabulary_id": SASDI_THEMES_VOCABULARY_NAME}
             )
-        click.echo(f"Deleting vocabulary {vocabulary_name!r}...")
-        toolkit.get_action("vocabulary_delete")(context, {"id": vocabulary_name})
+        click.echo(f"Deleting vocabulary {SASDI_THEMES_VOCABULARY_NAME!r}...")
+        toolkit.get_action("vocabulary_delete")(
+            context, {"id": SASDI_THEMES_VOCABULARY_NAME}
+        )
     else:
         click.secho(
-            f"Vocabulary {vocabulary_name!r} does not exist, nothing to do", fg="yellow"
+            (
+                f"Vocabulary {SASDI_THEMES_VOCABULARY_NAME!r} does not exist, "
+                f"nothing to do"
+            ),
+            fg="yellow",
         )
     click.secho(f"Done!", fg="green")

--- a/ckanext/dalrrd_emc_dcpr/commands.py
+++ b/ckanext/dalrrd_emc_dcpr/commands.py
@@ -4,6 +4,8 @@ import logging
 
 import click
 
+from ckan.plugins import toolkit
+
 logger = logging.getLogger(__name__)
 
 
@@ -15,3 +17,100 @@ def dalrrd_emc_dcpr():
 @dalrrd_emc_dcpr.command(short_help="Example command")
 def test_ckan_command():
     click.secho("Hi world!", fg="green")
+
+
+@dalrrd_emc_dcpr.group()
+def bootstrap():
+    """Commands for bootstrapping the dalrrd-emc-dcpr extension"""
+
+
+@bootstrap.command()
+def create_sasdi_themes():
+    """Create SASDI themes
+
+    This command adds a CKAN vocabulary for the SASDI themes and creates each theme
+    as a CKAN tag.
+
+    This command can safely be called multiple times - it will only ever create the
+    vocabulary and themes once.
+
+    """
+
+    vocabulary_name = "sasdi_themes"
+    click.secho(
+        f"Creating {vocabulary_name!r} CKAN tag vocabulary and adding configured SASDI "
+        f"themes to it..."
+    )
+
+    user = toolkit.get_action("get_site_user")({"ignore_auth": True}, {})
+    context = {"user": user["name"]}
+    vocab_list = toolkit.get_action("vocabulary_list")(context)
+    for voc in vocab_list:
+        if voc["name"] == vocabulary_name:
+            vocabulary = voc
+            click.secho(
+                f"Vocabulary {vocabulary_name!r} already exists, skipping creation...",
+                fg="yellow",
+            )
+            break
+    else:
+        click.echo(f"Creating vocabulary {vocabulary_name!r}...")
+        vocabulary = toolkit.get_action("vocabulary_create")(
+            context, {"name": vocabulary_name}
+        )
+
+    for theme_name in toolkit.config.get(
+        "ckan.dalrrd_emc_dcpr.sasdi_themes"
+    ).splitlines():
+        if theme_name != "":
+            already_exists = theme_name in [tag["name"] for tag in vocabulary["tags"]]
+            if not already_exists:
+                click.echo(
+                    f"Adding tag {theme_name!r} to vocabulary {vocabulary_name!r}..."
+                )
+                toolkit.get_action("tag_create")(
+                    context, {"name": theme_name, "vocabulary_id": vocabulary["id"]}
+                )
+            else:
+                click.secho(
+                    f"Tag {theme_name!r} is already part of the {vocabulary_name!r} vocabulary, skipping...",
+                    fg="yellow",
+                )
+    click.secho("Done!", fg="green")
+
+
+@bootstrap.command(short_help="Example bootstrap command")
+def delete_sasdi_themes():
+    """Delete SASDI themes
+
+    This command adds a CKAN vocabulary for the SASDI themes and creates each theme
+    as a CKAN tag.
+
+    This command can safely be called multiple times - it will only ever delete the
+    vocabulary and themes once, if they exist.
+
+    """
+
+    user = toolkit.get_action("get_site_user")({"ignore_auth": True}, {})
+    context = {"user": user["name"]}
+    vocabulary_name = "sasdi_themes"
+    vocabulary_list = toolkit.get_action("vocabulary_list")(context)
+    if vocabulary_name in [voc["name"] for voc in vocabulary_list]:
+        click.secho(
+            f"Deleting {vocabulary_name!r} CKAN tag vocabulary and respective tags... "
+        )
+        existing_tags = toolkit.get_action("tag_list")(
+            context, {"vocabulary_id": vocabulary_name}
+        )
+        for tag_name in existing_tags:
+            click.secho(f"Deleting tag {tag_name!r}...")
+            toolkit.get_action("tag_delete")(
+                context, {"id": tag_name, "vocabulary_id": vocabulary_name}
+            )
+        click.echo(f"Deleting vocabulary {vocabulary_name!r}...")
+        toolkit.get_action("vocabulary_delete")(context, {"id": vocabulary_name})
+    else:
+        click.secho(
+            f"Vocabulary {vocabulary_name!r} does not exist, nothing to do", fg="yellow"
+        )
+    click.secho(f"Done!", fg="green")

--- a/ckanext/dalrrd_emc_dcpr/commands.py
+++ b/ckanext/dalrrd_emc_dcpr/commands.py
@@ -1,6 +1,10 @@
 """CKAN CLI commands for the dalrrd-emc-dcpr extension"""
 
+import dataclasses
 import logging
+import typing
+from functools import partial
+from pathlib import Path
 
 import click
 
@@ -10,15 +14,56 @@ from .constants import SASDI_THEMES_VOCABULARY_NAME
 
 logger = logging.getLogger(__name__)
 
+_DEFAULT_COLOR: typing.Final[typing.Optional[str]] = None
+_SUCCESS_COLOR: typing.Final[str] = "green"
+_ERROR_COLOR: typing.Final[str] = "red"
+_INFO_COLOR: typing.Final[str] = "yellow"
+
+
+@dataclasses.dataclass
+class _CkanBootstrapOrganization:
+    title: str
+    description: str
+    image_url: typing.Optional[Path] = None
+
+    @property
+    def name(self):
+        return self.title.replace(" ", "-").lower()[:100]
+
+
+_SASDI_ORGANIZATIONS: typing.Final[typing.List[_CkanBootstrapOrganization]] = [
+    _CkanBootstrapOrganization(
+        title="NSIF",
+        description=(
+            "The National Spatial Information Framework (NSIF) is a directorate "
+            "established in the Department of Rural Development and Land Reform, "
+            "within the Branch: National Geomatics Management Services to "
+            "facilitate the development and implementation of the South African "
+            "Spatial Data Infrastructure (SASDI), established in terms of "
+            "Section 3 of the Spatial Data Infrastructure Act (SDI Act No. 54, "
+            "2003). The NSIF also serves as secretariat to the Committee for "
+            "Spatial Information (CSI), established under Section 5 of the SDI "
+            "Act. "
+        ),
+    ),
+    _CkanBootstrapOrganization(
+        title="CSI",
+        description=(
+            "The Spatial Data Infrastructure Act (Act No. 54 of 2003) mandates "
+            "the Committee for Spatial Information (CSI) to amongst others advise "
+            "the Minister, the Director General and other Organs of State on "
+            "matters regarding the capture, management, integration, distribution "
+            "and utilisation of geo-spatial information. The CSI through its six "
+            "subcommittees developed a Programme of Work to guide the work to be "
+            "done by the CSI in achieving the objectives of SASDI."
+        ),
+    ),
+]
+
 
 @click.group(short_help="Commands related to the dalrrd-emc-dcpr extension.")
 def dalrrd_emc_dcpr():
     """Commands related to the dalrrd-emc-dcpr extension."""
-
-
-@dalrrd_emc_dcpr.command(short_help="Example command")
-def test_ckan_command():
-    click.secho("Hi world!", fg="green")
 
 
 @dalrrd_emc_dcpr.group()
@@ -54,7 +99,7 @@ def create_sasdi_themes():
                     f"Vocabulary {SASDI_THEMES_VOCABULARY_NAME!r} already exists, "
                     f"skipping creation..."
                 ),
-                fg="yellow",
+                fg=_INFO_COLOR,
             )
             break
     else:
@@ -82,9 +127,9 @@ def create_sasdi_themes():
                         f"Tag {theme_name!r} is already part of the "
                         f"{SASDI_THEMES_VOCABULARY_NAME!r} vocabulary, skipping..."
                     ),
-                    fg="yellow",
+                    fg=_INFO_COLOR,
                 )
-    click.secho("Done!", fg="green")
+    click.secho("Done!", fg=_SUCCESS_COLOR)
 
 
 @bootstrap.command()
@@ -125,49 +170,82 @@ def delete_sasdi_themes():
                 f"Vocabulary {SASDI_THEMES_VOCABULARY_NAME!r} does not exist, "
                 f"nothing to do"
             ),
-            fg="yellow",
+            fg=_INFO_COLOR,
         )
-    click.secho(f"Done!", fg="green")
+    click.secho(f"Done!", fg=_SUCCESS_COLOR)
 
 
 @bootstrap.command()
-def create_organizations():
+def create_sasdi_organizations():
     """Create main SASDI organizations
 
-    This command creates the main SASDI organizations: NSIF, CSI.
+    This command creates the main SASDI organizations.
 
-    It can safely be called multiple times - it will only ever create the
-    organizations once, if they do not exist already.
+    This function may fail if the SASDI organizations already exist but are disabled,
+    which can happen if they are deleted using the CKAN web frontend.
+
+    This is a product of a CKAN limitation whereby it is not possible to retrieve a
+    list of organizations regardless of their status - it will only return those that
+    are active.
 
     """
-    organizations = [
-        {
-            "name": "NSIF",
-            "description": "This is the NSIF organization",
-            "image": None,
-            "custom_fields": [],
-            "members": [
-                {
-                    "id": None,
-                    "role": "admin",
-                }
-            ],
+
+    existing_organizations = toolkit.get_action("organization_list")(
+        context={},
+        data_dict={
+            "organizations": [org.name for org in _SASDI_ORGANIZATIONS],
+            "all_fields": False,
         },
-    ]
-    for org_details in organizations:
+    )
+    user = toolkit.get_action("get_site_user")({"ignore_auth": True}, {})
+    create_action: typing.Callable = partial(toolkit.get_action("organization_create"))
+    for org_details in _SASDI_ORGANIZATIONS:
+        if org_details.name not in existing_organizations:
+            click.secho(f"Creating organization {org_details.name!r}...")
+            try:
+                create_action(
+                    context={
+                        "user": user["name"],
+                        "return_id_only": True,
+                    },
+                    data_dict={
+                        "name": org_details.name,
+                        "title": org_details.title,
+                        "description": org_details.description,
+                        "image_url": org_details.image_url,
+                    },
+                )
+            except toolkit.ValidationError as exc:
+                click.secho(
+                    f"Could not create organization {org_details.name!r}: {exc}",
+                    fg=_ERROR_COLOR,
+                )
+    click.secho("Done!", fg=_SUCCESS_COLOR)
+
+
+@bootstrap.command()
+def delete_sasdi_organizations():
+    """Delete the main SASDI organizations.
+
+    This command will delete the SASDI organizations from the CKAN DB - CKAN refers to
+    this as purging the organizations (the CKAN default behavior is to have the delete
+    command simply disable the existing organizations, but keeping them in the DB).
+
+    It can safely be called multiple times - it will only ever delete the
+    organizations once.
+
+    """
+
+    user = toolkit.get_action("get_site_user")({"ignore_auth": True}, {})
+    for org_details in _SASDI_ORGANIZATIONS:
+        click.secho(f"Purging  organization {org_details.name!r}...")
         try:
-            current_org = toolkit.get_action("organization_show")(
-                context={},
-                data_dict={
-                    "id": org_details["name"],
-                    "include_datasets": False,
-                    "include_dataset_count": False,
-                    "include_extras": True,
-                    "include_users": True,
-                    "include_groups": True,
-                    "include_tags": True,
-                },
+            toolkit.get_action("organization_purge")(
+                context={"user": user["name"]}, data_dict={"id": org_details.name}
             )
-            click.echo(f"current_org: {current_org}")
         except toolkit.ObjectNotFound:
-            click.echo(f"Could not find org {org_details['name']!r}")
+            click.secho(
+                f"Organization {org_details.name!r} does not exist, skipping...",
+                fg=_INFO_COLOR,
+            )
+    click.secho(f"Done!", fg=_SUCCESS_COLOR)

--- a/ckanext/dalrrd_emc_dcpr/constants.py
+++ b/ckanext/dalrrd_emc_dcpr/constants.py
@@ -1,0 +1,3 @@
+import typing
+
+SASDI_THEMES_VOCABULARY_NAME: typing.Final[str] = "sasdi_themes"

--- a/ckanext/dalrrd_emc_dcpr/plugin.py
+++ b/ckanext/dalrrd_emc_dcpr/plugin.py
@@ -115,8 +115,22 @@ class DalrrdEmcDcprPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
             blueprint.dcpr_blueprint,
         ]
 
-    def dataset_facets(self, facets_dict: typing.OrderedDict, package_type: str):
+    def dataset_facets(
+        self, facets_dict: typing.OrderedDict, package_type: str
+    ) -> typing.OrderedDict:
         facets_dict[f"vocab_{SASDI_THEMES_VOCABULARY_NAME}"] = toolkit._("SASDI theme")
+        return facets_dict
+
+    def group_facets(
+        self, facets_dict: typing.OrderedDict, group_type: str, package_type: str
+    ) -> typing.OrderedDict:
+        """IFacets interface requires reimplementation of all facets-related methods
+
+        In this case we do not really need to override this method, but need to satisfy
+        IFacets.
+
+        """
+
         return facets_dict
 
 

--- a/ckanext/dalrrd_emc_dcpr/plugin.py
+++ b/ckanext/dalrrd_emc_dcpr/plugin.py
@@ -12,10 +12,8 @@ from ckan.lib.navl.dictization_functions import (
     Missing,
 )  # note: imported for type hints only
 
-from . import (
-    blueprint,
-    commands,
-)
+from . import blueprint
+from .cli import commands
 from .constants import SASDI_THEMES_VOCABULARY_NAME
 from .logic.action import ckan as ckan_actions
 from .logic.action import dcpr as dcpr_actions

--- a/ckanext/dalrrd_emc_dcpr/templates/package/snippets/additional_info.html
+++ b/ckanext/dalrrd_emc_dcpr/templates/package/snippets/additional_info.html
@@ -1,0 +1,14 @@
+{% ckan_extends %}
+
+{% block package_additional_info %}
+
+    {% if pkg_dict.sasdi_theme %}
+        <tr>
+            <th scope="row" class="dataset-label">{{ _("SASDI Theme") }}</th>
+            <td class="dataset-details">{{ pkg_dict.sasdi_theme[0] }}</td>
+        </tr>
+    {% endif %}
+
+    {{ super() }}
+
+{% endblock %}

--- a/ckanext/dalrrd_emc_dcpr/templates/package/snippets/package_metadata_fields.html
+++ b/ckanext/dalrrd_emc_dcpr/templates/package/snippets/package_metadata_fields.html
@@ -1,0 +1,19 @@
+{% ckan_extends %}
+
+{% block package_metadata_fields %}
+
+    <div class="form-group control-medium">
+        <label for="field-sasdi_theme" class="control-label">{{ _('SASDI Theme') }}</label>
+        <div class="controls">
+            <select id="field-sasdi_theme" name="sasdi_theme" data-module="autocomplete">
+                <option value="">{{ _('No SASDI Theme') }}</option>
+                {% for sasdi_theme in h.sasdi_themes()  %}
+                    <option value="{{ sasdi_theme }}" {% if sasdi_theme in data.get('sasdi_theme', []) %}selected="selected"{% endif %}>{{ sasdi_theme }}</option>
+                {% endfor %}
+            </select>
+        </div>
+    </div>
+
+    {{ super() }}
+
+{% endblock %}

--- a/ckanext/dalrrd_emc_dcpr/tests/test_cli_commands.py
+++ b/ckanext/dalrrd_emc_dcpr/tests/test_cli_commands.py
@@ -1,13 +1,23 @@
+import typing
+
 import pytest
 
 from ckan.tests.helpers import CKANCliRunner
 
-from .. import commands
+from ..cli import commands
 
 pytestmark = pytest.mark.unit
 
 
-def test_cli_command():
+@pytest.mark.parametrize(
+    "command",
+    [
+        pytest.param(commands.bootstrap),
+        pytest.param(commands.load_sample_data),
+        pytest.param(commands.delete_data),
+    ],
+)
+def test_group_commands(command: typing.Callable):
     runner = CKANCliRunner()
-    result = runner.invoke(commands.test_ckan_command)
-    assert result.output.strip() == "Hi world!"
+    result = runner.invoke(command)
+    assert result.exit_code == 0

--- a/docker/ckan-dev-settings.ini
+++ b/docker/ckan-dev-settings.ini
@@ -258,6 +258,21 @@ ckan.dalrrd_emc_dcpr.default_spatial_search_extent =
         ]
     }
 
+ckan.dalrrd_emc_dcpr.sasdi_themes =
+    Administrative boundaries 1
+    Administrative boundaries 2
+    Aerial Imagery
+    Satellite Imagery
+    Cadastre
+    Conservation
+    Geodesy
+    Hydrology
+    Wetlands
+    Land Cover
+    Land Use
+    Social Statistics
+    Transport
+
 ## Logging configuration
 [loggers]
 keys = root, ckan, ckanext, werkzeug


### PR DESCRIPTION
This PR adds some ckan CLI commands. They can be ran by issuing the following incantation:

```
docker exec -ti emc-dcpr_ckan-web_1 poetry run ckan <command>
``` 

This PR contains commands for:

-  Bootstrapping the creation of various entities needed by the system. For now there are two commands:

    -  `poetry run ckan dalrrd-emc-dcpr bootstrap create-sasdi-organizations` - This creates the NSIF and CSI organizations
    - `poetry run ckan dalrrd-ec-dcpr bootstrap create-sasdi-themes` - This creates the SASDI themes
 
-  Adding sample data for development purposes. For now there are is a single command:

    - `poetry run ckan dalrrd-emc-dcpr load-sample-data  create-sample-organizations` - This creates some sample users, organizations, and memberships with various roles (member, editor, publisher) 

-  Deleting the bootstrap and sample data:

    - `poetry run ckan dalrrd-emc-dcpr delete-data delete-sasdi-organizations`
    - `poetry run ckan dalrrd-emc-dcpr delete-data delete-sasdi-themes`
    - `poetry run ckan dalrrd-emc-dcpr delete-data delete-sample-organizations`

fixes #24 
fixes #57