### PR TITLE
Add API endpoint and footer section to show current version

### DIFF
--- a/.github/actions/action-common-ci/action.yml
+++ b/.github/actions/action-common-ci/action.yml
@@ -16,7 +16,7 @@ runs:
       uses: jpetrucciani/mypy-check@master
       with:
         path: "ckanext"
-        mypy_flags: "--install-types"
+        mypy_flags: "--install-types --non-interactive"
 
     - name: Setup docker buildx
       uses: docker/setup-buildx-action@v1.6.0

--- a/.github/actions/action-common-ci/action.yml
+++ b/.github/actions/action-common-ci/action.yml
@@ -16,6 +16,7 @@ runs:
       uses: jpetrucciani/mypy-check@master
       with:
         path: "ckanext"
+        mypy_flags: "--install-types"
 
     - name: Setup docker buildx
       uses: docker/setup-buildx-action@v1.6.0

--- a/ckanext/dalrrd_emc_dcpr/helpers.py
+++ b/ckanext/dalrrd_emc_dcpr/helpers.py
@@ -6,6 +6,7 @@ from shapely import geometry
 from ckan.plugins import toolkit
 
 from . import constants
+from .logic.action.emc import show_version
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +45,10 @@ def get_default_spatial_search_extent(
     else:
         result = configured_extent
     return result
+
+
+def helper_show_version(*args, **kwargs) -> typing.Dict:
+    return show_version()
 
 
 def _pad_geospatial_extent(extent: typing.Dict, padding: float) -> typing.Dict:

--- a/ckanext/dalrrd_emc_dcpr/logic/action/dcpr.py
+++ b/ckanext/dalrrd_emc_dcpr/logic/action/dcpr.py
@@ -6,6 +6,7 @@ import ckan.plugins.toolkit as toolkit
 logger = logging.getLogger(__name__)
 
 
+@toolkit.side_effect_free
 def dcpr_request_list(context: typing.Dict, data_dict: typing.Dict) -> typing.List:
     logger.debug("Inside the dcpr_request_list action")
     access_result = toolkit.check_access(

--- a/ckanext/dalrrd_emc_dcpr/logic/action/emc.py
+++ b/ckanext/dalrrd_emc_dcpr/logic/action/emc.py
@@ -1,0 +1,20 @@
+import logging
+import os
+import pkg_resources
+import typing
+
+import ckan.plugins.toolkit as toolkit
+
+logger = logging.getLogger(__name__)
+
+
+@toolkit.side_effect_free
+def show_version(
+    context: typing.Optional[typing.Dict] = None,
+    data_dict: typing.Optional[typing.Dict] = None,
+) -> typing.Dict:
+    """return the current version of this project"""
+    return {
+        "version": pkg_resources.require("ckanext-dalrrd-emc-dcpr")[0].version,
+        "git_sha": os.getenv("GIT_COMMIT"),
+    }

--- a/ckanext/dalrrd_emc_dcpr/plugin.py
+++ b/ckanext/dalrrd_emc_dcpr/plugin.py
@@ -15,6 +15,7 @@ from . import (
 from .cli import commands
 from .logic.action import ckan as ckan_actions
 from .logic.action import dcpr as dcpr_actions
+from .logic.action import emc as emc_actions
 from .logic import (
     auth,
     validators,
@@ -57,6 +58,7 @@ class DalrrdEmcDcprPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
             "package_update": ckan_actions.package_update,
             "package_patch": ckan_actions.package_patch,
             "dcpr_request_list": dcpr_actions.dcpr_request_list,
+            "emc_version": emc_actions.show_version,
         }
 
     def get_validators(self) -> typing.Dict[str, typing.Callable]:
@@ -119,6 +121,7 @@ class DalrrdEmcDcprPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
             ),
             "emc_sasdi_themes": helpers.get_sasdi_themes,
             "emc_iso_topic_categories": helpers.get_iso_topic_categories,
+            "emc_show_version": helpers.helper_show_version,
         }
 
     def get_blueprint(self) -> typing.List[Blueprint]:

--- a/ckanext/dalrrd_emc_dcpr/templates/footer.html
+++ b/ckanext/dalrrd_emc_dcpr/templates/footer.html
@@ -1,0 +1,13 @@
+{% ckan_extends %}
+
+{#
+    below we reimplement the default footer_links block in order to include the current version of
+    CKAN and of the EMC
+#}
+
+{% set emc_version = h.emc_show_version() %}
+
+{% block footer_links %}
+    <li>SASDI EMC/DCPR v{{ emc_version.version }} (git sha: {{ emc_version.git_sha }})</li>
+    <li>CKAN v{{ h.ckan_version() }}</li>
+{% endblock %}

--- a/poetry.lock
+++ b/poetry.lock
@@ -1166,6 +1166,14 @@ python-versions = ">=3.7"
 test = ["pytest"]
 
 [[package]]
+name = "types-setuptools"
+version = "57.4.9"
+description = "Typing stubs for setuptools"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "typing-extensions"
 version = "4.0.1"
 description = "Backported and Experimental Type Hints for Python 3.6+"
@@ -1282,7 +1290,7 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "21a27a54d76bb13e0e6644997cde1ca8f45b1591de49085c142954618a2daa59"
+content-hash = "fcac532bd1e1ce2c7424fdfe320a3134581bd3215ddc29546a685290a6450bfc"
 
 [metadata.files]
 alembic = [
@@ -2007,6 +2015,10 @@ tomli = [
 traitlets = [
     {file = "traitlets-5.1.1-py3-none-any.whl", hash = "sha256:2d313cc50a42cd6c277e7d7dc8d4d7fedd06a2c215f78766ae7b1a66277e0033"},
     {file = "traitlets-5.1.1.tar.gz", hash = "sha256:059f456c5a7c1c82b98c2e8c799f39c9b8128f6d0d46941ee118daace9eb70c7"},
+]
+types-setuptools = [
+    {file = "types-setuptools-57.4.9.tar.gz", hash = "sha256:536ef74744f8e1e4be4fc719887f886e74e4cf3c792b4a06984320be4df450b5"},
+    {file = "types_setuptools-57.4.9-py3-none-any.whl", hash = "sha256:948dc6863373750e2cd0b223a84f1fb608414cde5e55cf38ea657b93aeb411d2"},
 ]
 typing-extensions = [
     {file = "typing_extensions-4.0.1-py3-none-any.whl", hash = "sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,7 @@ factory-boy = "^3.2.0"
 mock = "^4.0.3"
 pytest-raises = "^0.11"
 mypy = "^0.931"
+types-setuptools = "^57.4.9"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/test_unit_logic_emc.py
+++ b/tests/test_unit_logic_emc.py
@@ -1,0 +1,21 @@
+import pkg_resources
+import pytest
+from unittest import mock
+
+from ckanext.dalrrd_emc_dcpr.logic.action import emc
+
+pytestmark = pytest.mark.unit
+
+
+@mock.patch("ckanext.dalrrd_emc_dcpr.logic.action.emc.os", autospec=True)
+@mock.patch("ckanext.dalrrd_emc_dcpr.logic.action.emc.pkg_resources", autospec=True)
+def test_show_version(mock_pkg_resources, mock_os):
+    fake_git_sha = "phony git sha"
+    fake_version = "phony version"
+    mock_os.getenv.return_value = fake_git_sha
+    mock_pkg_resources_working_set = mock.MagicMock(pkg_resources.WorkingSet)
+    mock_pkg_resources_working_set.version = fake_version
+    mock_pkg_resources.require.return_value = [mock_pkg_resources_working_set]
+    result = emc.show_version()
+    assert result["git_sha"] == fake_git_sha
+    assert result["version"] == fake_version


### PR DESCRIPTION
The current version is now shown on the main UI's footer. It is also shown via the API, as shown below when using [httpie](https://httpie.io/)

```
http localhost:5000/api/3/action/emc_version

HTTP/1.1 200 OK
Cache-Control: public, max-age=0, must-revalidate
Connection: close
Content-Length: 144
Content-Type: application/json;charset=utf-8
Date: Mon, 14 Feb 2022 12:47:02 GMT
Server: gunicorn

{
    "help": "http://localhost:5000/api/3/action/help_show?name=emc_version",
    "result": {
        "git_sha": "97804bd",
        "version": "0.1.0"
    },
    "success": true
}

```

fixes #62
fixes #63