### PR TITLE
Configure CKAN email notification settings

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,8 @@ Dockerfile
 
 **/__pycache__
 
+docker/.env
+
 .git
 
 node_modules

--- a/README.md
+++ b/README.md
@@ -118,49 +118,73 @@ guide to install CKAN, then follow the below steps:
 
 ## Operations
 
-- Rebuild solr index
+#### Rebuild solr index
 
-  ```
-  # check if there are any datasets that are not indexed
-  ckan search-index check
+```
+# check if there are any datasets that are not indexed
+ckan search-index check
 
-  # re-index
-  ckan search-index rebuild
-  ```
+# re-index
+ckan search-index rebuild
+```
 
-- Update extents of spatial datasets
 
-  ```
-  ckan spatial extents
-  ```
+#### Update extents of spatial datasets
 
-- Create bootstrap items
+```
+ckan spatial extents
+```
 
-  ```
-  ckan dalrrd-emc-dcpr bootstrap create-sasdi-themes
-  ckan dalrrd-emc-dcpr bootstrap create-iso-topic-categories
-  ckan dalrrd-emc-dcpr bootstrap create-sasdi-organizations
-  ```
 
-- Update page view tracking - This needs to be run
-  periodically (once per day is enough). Be sure to
-  run both commands depicted below.
+#### Create bootstrap items
 
-  ```
-  ckan tracking update
-  ckan search-index rebuild --refresh
-  ```
+```
+ckan dalrrd-emc-dcpr bootstrap create-sasdi-themes
+ckan dalrrd-emc-dcpr bootstrap create-iso-topic-categories
+ckan dalrrd-emc-dcpr bootstrap create-sasdi-organizations
+```
 
-- Operate harvesters
 
-  You may use the various `ckan harvester <command>` commands to operate existing
-  harvesters
+#### Update page view tracking
 
-  - create a job
+This needs to be run periodically (once per day is enough). Be sure to run both commands depicted below.
 
-    ```
-    docker exec -ti emc_dcpr-ckan_harvesting-runner poetry run ckan harvester job <source-id>
-    ```
+```
+ckan tracking update
+ckan search-index rebuild --refresh
+```
+
+
+#### Operate harvesters
+
+You may use the various `ckan harvester <command>` commands to operate existing
+harvesters
+
+Create a job:
+
+```
+docker exec -ti emc_dcpr-ckan_harvesting-runner poetry run ckan harvester job <source-id>
+```
+
+
+#### Send notifications by email
+
+This needs to be run periodically (once per hour is likely enough).
+
+```
+ckan dalrrd-emc-dcpr send-email-notifications
+```
+
+Additionally, in order for notifications to work, there is some configuration:
+
+- The CKAN settings must have `ckan.activity_streams_email_notifications = true`
+- The CKAN settings must have the relevant email configuration (likely being passed
+  as environment variables)
+- Each user must manually choose to receive notification e-mails - This is done in
+  the user's profile
+- Each user must manually follow those entities (datasets, organizations, etc) that
+  it finds interesting enough in order to be notified of changes via email
+
 
 
 ## Development

--- a/ckanext/dalrrd_emc_dcpr/cli/commands.py
+++ b/ckanext/dalrrd_emc_dcpr/cli/commands.py
@@ -9,6 +9,7 @@ import click
 from ckan.plugins import toolkit
 from ckan import model
 from ckan.lib.navl import dictization_functions
+from ckan.lib.email_notifications import get_and_send_notifications_for_all_users
 
 from ..constants import (
     ISO_TOPIC_CATEGOY_VOCABULARY_NAME,
@@ -32,6 +33,27 @@ _INFO_COLOR: typing.Final[str] = "yellow"
 @click.group()
 def dalrrd_emc_dcpr():
     """Commands related to the dalrrd-emc-dcpr extension."""
+
+
+@dalrrd_emc_dcpr.command()
+def send_email_notifications():
+    """Send pending email notifications to users
+
+    This command should be ran periodically.
+
+    """
+
+    # FIXME: This is failing with RuntimeError: Working outside of request context
+    # seems like we need to call this function from the API instead
+    setting_key = "ckan.activity_streams_email_notifications"
+    send_notification_emails = toolkit.asbool(toolkit.config.get(setting_key))
+    if toolkit.asbool(toolkit.config.get(setting_key)):
+        get_and_send_notifications_for_all_users()
+        click.secho("Done!", fg=_SUCCESS_COLOR)
+    else:
+        click.secho(
+            f"{setting_key} is not enabled in config. Aborting", fg=_ERROR_COLOR
+        )
 
 
 @dalrrd_emc_dcpr.group()

--- a/ckanext/dalrrd_emc_dcpr/cli/commands.py
+++ b/ckanext/dalrrd_emc_dcpr/cli/commands.py
@@ -46,8 +46,6 @@ def send_email_notifications():
 
     """
 
-    # FIXME: This is failing with RuntimeError: Working outside of request context
-    # seems like we need to call this function from the API instead
     setting_key = "ckan.activity_streams_email_notifications"
     if toolkit.asbool(toolkit.config.get(setting_key)):
         env_sentinel = "CKAN_SMTP_PASSWORD"

--- a/ckanext/dalrrd_emc_dcpr/email_notifications.py
+++ b/ckanext/dalrrd_emc_dcpr/email_notifications.py
@@ -1,0 +1,254 @@
+"""Reimplementation of the core CKAN email notifications
+
+This module reimplements the core CKAN email notifications in order to provide more
+visibility on to what is going on.
+
+"""
+
+import datetime as dt
+import logging
+import re
+
+from ckan import (
+    logic,
+    model,
+)
+from ckan.lib import base
+from ckan.plugins import toolkit
+from flask import render_template
+
+logger = logging.getLogger(__name__)
+
+
+def get_and_send_notifications_for_all_users() -> int:
+    context = {
+        "model": model,
+        "session": model.Session,
+        "ignore_auth": True,
+        "keep_email": True,
+    }
+    users = logic.get_action("user_list")(context, {})
+    num_sent = 0
+    for user in users:
+        logger.debug(f"Processing notifications for user {user!r}...")
+        num_sent += get_and_send_notifications_for_user(user)
+    return num_sent
+
+
+def get_and_send_notifications_for_user(user) -> int:
+
+    # Parse the email_notifications_since config setting, email notifications
+    # from longer ago than this time will not be sent.
+    email_notifications_since = toolkit.config.get(
+        "ckan.email_notifications_since", "2 days"
+    )
+    email_notifications_since = string_to_timedelta(email_notifications_since)
+    email_notifications_since = dt.datetime.utcnow() - email_notifications_since
+
+    # FIXME: We are accessing model from lib here but I'm not sure what
+    # else to do unless we add a get_email_last_sent() logic function which
+    # would only be needed by this lib.
+    email_last_sent = model.Dashboard.get(user["id"]).email_last_sent
+    activity_stream_last_viewed = model.Dashboard.get(
+        user["id"]
+    ).activity_stream_last_viewed
+
+    since = max(email_notifications_since, email_last_sent, activity_stream_last_viewed)
+
+    notifications = get_notifications(user, since)
+    logger.debug(f"About to send the following notifications: {notifications=}")
+    num_sent = 0
+    # TODO: Handle failures from send_email_notification.
+    for notification in notifications:
+        logger.debug(f"Processing notification {notification=}...")
+        send_notification(user, notification)
+        num_sent += 1
+
+    # FIXME: We are accessing model from lib here but I'm not sure what
+    # else to do unless we add a update_email_last_sent()
+    # logic function which would only be needed by this lib.
+    dash = model.Dashboard.get(user["id"])
+    dash.email_last_sent = dt.datetime.utcnow()
+    model.repo.commit()
+    return num_sent
+
+
+def send_notification(user, email_dict):
+    """Email `email_dict` to `user`."""
+    import ckan.lib.mailer
+
+    if not user.get("email"):
+        logger.debug(f"User {user!r} does not have an email address configured")
+        # FIXME: Raise an exception.
+        return
+
+    try:
+        ckan.lib.mailer.mail_recipient(
+            user["display_name"],
+            user["email"],
+            email_dict["subject"],
+            email_dict["body"],
+        )
+    except ckan.lib.mailer.MailerException:
+        raise
+    else:
+        logger.debug(f"Email sent!")
+
+
+def _notifications_for_activities(activities, user_dict):
+    """Return one or more email notifications covering the given activities.
+
+    This function handles grouping multiple activities into a single digest
+    email.
+
+    :param activities: the activities to consider
+    :type activities: list of activity dicts like those returned by
+        ckan.logic.action.get.dashboard_activity_list()
+
+    :returns: a list of email notifications
+    :rtype: list of dicts each with keys 'subject' and 'body'
+
+    """
+    logger.debug(f"inside _notifications_for_activities. {locals()=}")
+    if not activities:
+        return []
+
+    if not user_dict.get("activity_streams_email_notifications"):
+        return []
+
+    # We just group all activities into a single "new activity" email that
+    # doesn't say anything about _what_ new activities they are.
+    # TODO: Here we could generate some smarter content for the emails e.g.
+    # say something about the contents of the activities, or single out
+    # certain types of activity to be sent in their own individual emails,
+    # etc.
+    subject = toolkit.ungettext(
+        "{n} new activity from {site_title}",
+        "{n} new activities from {site_title}",
+        len(activities),
+    ).format(site_title=toolkit.config.get("ckan.site_title"), n=len(activities))
+    body = render_template(
+        "activity_streams/activity_stream_email_notifications.text",
+        extra_vars={"activities": activities},
+    )
+    # body = base.render(
+    #     'activity_streams/activity_stream_email_notifications.text',
+    #     extra_vars={'activities': activities})
+    notifications = [{"subject": subject, "body": body}]
+    logger.debug(f"Returning the following notifications: {notifications=}")
+
+    return notifications
+
+
+def _notifications_from_dashboard_activity_list(user_dict, since):
+    """Return any email notifications from the given user's dashboard activity
+    list since `since`.
+
+    """
+    # Get the user's dashboard activity stream.
+    context = {"model": model, "session": model.Session, "user": user_dict["id"]}
+    activities = logic.get_action("dashboard_activity_list")(context, {})
+
+    # Filter out the user's own activities., so they don't get an email every
+    # time they themselves do something (we are not Trac).
+    activities = [act for act in activities if act["user_id"] != user_dict["id"]]
+
+    # Filter out the old activities.
+    strptime = dt.datetime.strptime
+    fmt = "%Y-%m-%dT%H:%M:%S.%f"
+    activities = [act for act in activities if strptime(act["timestamp"], fmt) > since]
+    return _notifications_for_activities(activities, user_dict)
+
+
+# A list of functions that provide email notifications for users from different
+# sources. Add to this list if you want to implement a new source of email
+# notifications.
+_notifications_functions = [
+    _notifications_from_dashboard_activity_list,
+]
+
+
+def get_notifications(user_dict, since):
+    """Return any email notifications for the given user since `since`.
+
+    For example email notifications about activity streams will be returned for
+    any activities the occurred since `since`.
+
+    :param user_dict: a dictionary representing the user, should contain 'id'
+        and 'name'
+    :type user_dict: dictionary
+
+    :param since: datetime after which to return notifications from
+    :rtype since: datetime.datetime
+
+    :returns: a list of email notifications
+    :rtype: list of dicts with keys 'subject' and 'body'
+
+    """
+    notifications = []
+    since = dt.datetime(2022, 2, 21)
+    logger.warning(f"Manually overridden the 'since' param to {since!r}")
+    logger.debug(f"Retrieving notifications for {user_dict['name']!r} since {since!r}")
+    for function in _notifications_functions:
+        logger.debug(f"Processing notification function {function!r}...")
+        notifications.extend(function(user_dict, since))
+    return notifications
+
+
+def string_to_timedelta(s):
+    """Parse a string s and return a standard datetime.timedelta object.
+
+    Handles days, hours, minutes, seconds, and microseconds.
+
+    Accepts strings in these formats:
+
+    2 days
+    14 days
+    4:35:00 (hours, minutes and seconds)
+    4:35:12.087465 (hours, minutes, seconds and microseconds)
+    7 days, 3:23:34
+    7 days, 3:23:34.087465
+    .087465 (microseconds only)
+
+    :raises ckan.logic.ValidationError: if the given string does not match any
+        of the recognised formats
+
+    """
+    patterns = []
+    days_only_pattern = "(?P<days>\d+)\s+day(s)?"
+    patterns.append(days_only_pattern)
+    hms_only_pattern = "(?P<hours>\d?\d):(?P<minutes>\d\d):(?P<seconds>\d\d)"
+    patterns.append(hms_only_pattern)
+    ms_only_pattern = ".(?P<milliseconds>\d\d\d)(?P<microseconds>\d\d\d)"
+    patterns.append(ms_only_pattern)
+    hms_and_ms_pattern = hms_only_pattern + ms_only_pattern
+    patterns.append(hms_and_ms_pattern)
+    days_and_hms_pattern = "{0},\s+{1}".format(days_only_pattern, hms_only_pattern)
+    patterns.append(days_and_hms_pattern)
+    days_and_hms_and_ms_pattern = days_and_hms_pattern + ms_only_pattern
+    patterns.append(days_and_hms_and_ms_pattern)
+
+    for pattern in patterns:
+        match = re.match("^{0}$".format(pattern), s)
+        if match:
+            break
+
+    if not match:
+        raise logic.ValidationError("Not a valid time: {0}".format(s))
+
+    gd = match.groupdict()
+    days = int(gd.get("days", "0"))
+    hours = int(gd.get("hours", "0"))
+    minutes = int(gd.get("minutes", "0"))
+    seconds = int(gd.get("seconds", "0"))
+    milliseconds = int(gd.get("milliseconds", "0"))
+    microseconds = int(gd.get("microseconds", "0"))
+    delta = dt.timedelta(
+        days=days,
+        hours=hours,
+        minutes=minutes,
+        seconds=seconds,
+        milliseconds=milliseconds,
+        microseconds=microseconds,
+    )
+    return delta

--- a/ckanext/dalrrd_emc_dcpr/email_notifications.py
+++ b/ckanext/dalrrd_emc_dcpr/email_notifications.py
@@ -128,7 +128,7 @@ def _notifications_for_activities(activities, user_dict):
         len(activities),
     ).format(site_title=toolkit.config.get("ckan.site_title"), n=len(activities))
     body = render_template(
-        "activity_streams/activity_stream_email_notifications.text",
+        "email_notifications/email_body.text",
         extra_vars={"activities": activities},
     )
     # body = base.render(

--- a/ckanext/dalrrd_emc_dcpr/templates/email_notifications/email_body.txt
+++ b/ckanext/dalrrd_emc_dcpr/templates/email_notifications/email_body.txt
@@ -1,0 +1,7 @@
+{% set num = activities|length %}{{ ungettext("You have {num} new activity on your {site_title} dashboard", "You have {num} new activities on your {site_title} dashboard", num).format(site_title=g.site_title, num=num) }} {{ _('To view your dashboard, click on this link:') }}
+
+{{ g.site_url + '/dashboard' }}
+
+{{ _('You can turn off these email notifications in your {site_title} preferences. To change your preferences, click on this link:').format(site_title=g.site_title) }}
+
+{{ g.site_url + '/user/edit' }}

--- a/ckanext/dalrrd_emc_dcpr/templates/email_notifications/email_body.txt
+++ b/ckanext/dalrrd_emc_dcpr/templates/email_notifications/email_body.txt
@@ -1,7 +1,7 @@
-{% set num = activities|length %}{{ ungettext("You have {num} new activity on your {site_title} dashboard", "You have {num} new activities on your {site_title} dashboard", num).format(site_title=g.site_title, num=num) }} {{ _('To view your dashboard, click on this link:') }}
+{% set num = activities|length %}{{ ngettext("You have {num} new activity on your {site_title} dashboard", "You have {num} new activities on your {site_title} dashboard", num).format(site_title=site_title, num=num) }} {{ _('To view your dashboard, click on this link:') }}
 
-{{ g.site_url + '/dashboard' }}
+{{ site_url + '/dashboard' }}
 
-{{ _('You can turn off these email notifications in your {site_title} preferences. To change your preferences, click on this link:').format(site_title=g.site_title) }}
+{{ _('You can turn off these email notifications in your {site_title} preferences. To change your preferences, click on this link:').format(site_title=site_title) }}
 
-{{ g.site_url + '/user/edit' }}
+{{ site_url + '/user/edit' }}

--- a/docker/ckan-dev-settings.ini
+++ b/docker/ckan-dev-settings.ini
@@ -235,10 +235,10 @@ ckan.webassets.path = /home/appuser/data/webassets
 
 ## Activity Streams Settings
 
-#ckan.activity_streams_enabled = true
-#ckan.activity_list_limit = 31
-#ckan.activity_streams_email_notifications = true
-#ckan.email_notifications_since = 2 days
+ckan.activity_streams_enabled = true
+ckan.activity_list_limit = 31
+ckan.activity_streams_email_notifications = true
+ckan.email_notifications_since = 2 days
 ckan.hide_activity_from_users = %(ckan.site_id)s
 
 

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -51,6 +51,15 @@ services:
   ckan-harvesting-runner:
     <<: *partial-ckan-volumes
 
+  ckan-mail-sender:
+    <<: *partial-ckan-volumes
+    environment:
+      CKAN_SMTP_SERVER: ${CKAN_SMTP_SERVER}
+      CKAN_SMTP_STARTTLS: ${CKAN_SMTP_STARTTLS}
+      CKAN_SMTP_USER: ${CKAN_SMTP_USER}
+      CKAN_SMTP_PASSWORD: ${CKAN_SMTP_PASSWORD}
+      CKAN_SMTP_MAIL_FROM: ${CKAN_SMTP_MAIL_FROM}
+
   ckan-db:
     environment:
       POSTGRES_USER: ckan-dev

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -18,6 +18,9 @@ services:
   ckan-harvesting-runner:
     image: kartoza/ckanext-dalrrd-emc-dcpr:${CKAN_IMAGE_TAG}
 
+  ckan-mail-sender:
+    image: kartoza/ckanext-dalrrd-emc-dcpr:${CKAN_IMAGE_TAG}
+
   ckan-db:
     image: postgis/postgis:13-3.1
     environment:


### PR DESCRIPTION
This PR implements email notifications. It re-implements some of the internal CKAN notitifcation sending machinery, in order to provide a bit more detail and also to not rely on the pexistence of a HTTP request (notifications are sent asynchronously, so they should not need a HTTP request to work).

Additional information has been added to the README

fixes #100