### PR TITLE
Improve creation of sample datasets in order to generate more of them

### DIFF
--- a/ckanext/dalrrd_emc_dcpr/cli/__init__.py
+++ b/ckanext/dalrrd_emc_dcpr/cli/__init__.py
@@ -1,5 +1,4 @@
 import dataclasses
-import datetime as dt
 import logging
 import typing
 from collections.abc import Iterable
@@ -44,8 +43,7 @@ class _CkanBootstrapResource:
     description: typing.Optional[str] = None
     resource_type: typing.Optional[str] = None
 
-    def to_data_dict(self):
-        logger.debug("Inside to_data_dict of the resource")
+    def to_data_dict(self) -> typing.Dict:
         result = {}
         for name, value in vars(self).items():
             if value is not None:
@@ -73,7 +71,7 @@ class _CkanBootstrapEmcDataset:
     maintainer_email: typing.Optional[str] = None
     type: typing.Optional[str] = "dataset"
     sasdi_theme: typing.Optional[str] = None
-    tags: typing.List[str] = dataclasses.field(default_factory=list)
+    tags: typing.List[typing.Dict] = dataclasses.field(default_factory=list)
 
     def to_data_dict(self) -> typing.Dict:
         result = {}
@@ -85,8 +83,10 @@ class _CkanBootstrapEmcDataset:
         return result
 
 
-def _to_data_dict(value: typing.Any):
-    if isinstance(value, Iterable):
+def _to_data_dict(value):
+    if isinstance(value, str):
+        result = value
+    elif isinstance(value, Iterable):
         try:
             result = [i.to_data_dict() for i in value]
         except AttributeError:

--- a/ckanext/dalrrd_emc_dcpr/cli/_sample_datasets.py
+++ b/ckanext/dalrrd_emc_dcpr/cli/_sample_datasets.py
@@ -1,42 +1,110 @@
+import datetime as dt
 import json
+import random
 import typing
+from itertools import count
 
+from ckan.plugins import toolkit
+
+from ..constants import ISO_TOPIC_CATEGORIES
 from . import (
     _CkanBootstrapEmcDataset,
     _CkanBootstrapResource,
 )
 
-SAMPLE_DATASETS: typing.Final[typing.List[_CkanBootstrapEmcDataset]] = [
-    _CkanBootstrapEmcDataset(
-        name="sample-ds-1",
-        private=False,
-        notes="Abstract for sample-ds-1",
-        reference_date="2022-01-01",
-        iso_topic_category="biota",
-        owner_org="sample-org-1",
-        maintainer="Nobody, No One, Ms.",
-        resources=[
-            _CkanBootstrapResource("http://fake.com", format="shp", format_version="1")
-        ],
-        spatial=json.dumps(
-            {
-                "type": "Polygon",
-                "coordinates": [
-                    [
-                        [10.0, 10.0],
-                        [10.31, 10.0],
-                        [10.31, 10.44],
-                        [10.0, 10.44],
-                        [10.0, 10.0],
-                    ]
-                ],
-            }
-        ),
-        equivalent_scale="500",
-        spatial_representation_type="001",
-        spatial_reference_system="EPSG:4326",
-        dataset_language="en",
-        metadata_language="en",
-        dataset_character_set="utf-8",
-    )
-]
+SAMPLE_DATASET_TAG = "sample-data"
+
+
+def generate_sample_datasets(
+    num_datasets: int,
+    name_prefix: str,
+    owner_org: str,
+    name_suffix: typing.Optional[str] = None,
+    temporal_range_start: dt.datetime = dt.datetime(2021, 1, 1),
+    temporal_range_end: dt.datetime = dt.datetime(2022, 12, 31),
+    latitude_range_start: float = -35,
+    latitude_range_end: float = -21,
+    longitude_range_start: float = 16.3,
+    longitude_range_end: float = 33,
+) -> typing.Iterator[_CkanBootstrapEmcDataset]:
+    possible_dates = _get_days(temporal_range_start, temporal_range_end)
+    sasdi_themes = [
+        t
+        for t in toolkit.config.get("ckan.dalrrd_emc_dcpr.sasdi_themes").splitlines()
+        if t != ""
+    ]
+    sasdi_themes.append(None)
+    for i in range(num_datasets):
+        name = f"{name_prefix}-{i}{'-' + name_suffix if name_suffix else ''}"
+        min_lon, max_lon, min_lat, max_lat = _get_random_temporal_extent(
+            latitude_range_start,
+            latitude_range_end,
+            longitude_range_start,
+            longitude_range_end,
+        )
+        yield _CkanBootstrapEmcDataset(
+            name=name,
+            private=random.choice((True, False)),
+            notes=f"Abstract for {name}",
+            reference_date=random.choice(possible_dates).strftime("%Y-%m-%d"),
+            iso_topic_category=ISO_TOPIC_CATEGORIES[
+                random.randrange(0, len(ISO_TOPIC_CATEGORIES))
+            ][0],
+            sasdi_theme=random.choice(sasdi_themes),
+            owner_org=owner_org,
+            maintainer="Nobody, No One, Ms.",
+            spatial=json.dumps(
+                {
+                    "type": "Polygon",
+                    "coordinates": [
+                        [
+                            [min_lon, min_lat],
+                            [max_lon, min_lat],
+                            [max_lon, max_lat],
+                            [min_lon, max_lat],
+                            [min_lon, min_lat],
+                        ]
+                    ],
+                }
+            ),
+            equivalent_scale=random.choice(
+                ("500", "1000", "5000", "10000", "20000", "50000")
+            ),
+            spatial_representation_type=random.choice(
+                ("001", "002", "003", "004", "007")
+            ),
+            spatial_reference_system=random.choice(("EPSG:4326", "EPSG:3857")),
+            dataset_language="en",
+            metadata_language="en",
+            dataset_character_set="utf-8",
+            resources=[
+                _CkanBootstrapResource(
+                    "http://fake.com", format="shp", format_version="1"
+                )
+            ],
+            tags=[{"name": SAMPLE_DATASET_TAG, "vocabulary_id": None}],
+        )
+
+
+def _get_days(start: dt.datetime, end: dt.datetime) -> typing.List[dt.datetime]:
+    result = []
+    for i in count():
+        current_date = start + dt.timedelta(days=i)
+        if current_date <= end:
+            result.append(current_date)
+        else:
+            break
+    return result
+
+
+def _get_random_temporal_extent(
+    latitude_start: float = -90,
+    latitude_end: float = 90,
+    longitude_start: float = -180,
+    longitude_end: float = 180,
+) -> typing.Tuple[float, float, float, float]:
+    lon_start = longitude_start + random.random() * (longitude_end - longitude_start)
+    lon_end = lon_start + random.random() * (longitude_end - lon_start)
+    lat_start = latitude_start + random.random() * (latitude_end - latitude_start)
+    lat_end = lat_start + random.random() * (latitude_end - lat_start)
+    return lon_start, lon_end, lat_start, lat_end

--- a/ckanext/dalrrd_emc_dcpr/plugin.py
+++ b/ckanext/dalrrd_emc_dcpr/plugin.py
@@ -60,6 +60,10 @@ class DalrrdEmcDcprPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
         """IPackageController interface requires reimplementation of this method."""
         return context, pkg_dict
 
+    def before_index(self, pkg_dict):
+        """IPackageController interface requires reimplementation of this method."""
+        return pkg_dict
+
     def before_search(self, search_params: typing.Dict):
         start_date = search_params.get("extras", {}).get("ext_start_reference_date")
         end_date = search_params.get("extras", {}).get("ext_end_reference_date")


### PR DESCRIPTION
This PR improves the CLI command that is able to generate sample datasets. It can now be called like this:

```sh
ckan dalrrd-emc-dcpr load-sample-data create-sample-datasets sample-org-1 -n 100 -p my-samples
```

Check the commands `help` for more info. Additionally, these sample datasets are created with a `sample-data` tag, which makes it easier to delete them later, if needed.

This means we can now generate as many sample datasets as needed!

fixes #103