### PR TITLE
Add help and about sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,9 +469,10 @@ To run the tests you will need to:
 1. Initialize the db - this is only needed the first time (the dev stack uses volumes to persist the DB)
 
    ```
-   docker exec -ti {container-name} poetry run ckan --config docker/ckan-test-settings.ini db init
-   docker exec -ti {container-name} poetry run ckan --config docker/ckan-test-settings.ini harvester initdb
-   docker exec -ti {container-name} poetry run ckan --config docker/ckan-test-settings.ini dalrrd-emc-dcpr bootstrap init-dcpr-requests
+   docker exec -ti emc-dcpr_ckan-web_1 poetry run ckan --config docker/ckan-test-settings.ini db init
+   docker exec -ti emc-dcpr_ckan-web_1 poetry run ckan --config docker/ckan-test-settings.ini harvester initdb
+   docker exec -ti emc-dcpr_ckan-web_1 poetry run ckan --config docker/ckan-test-settings.ini dalrrd-emc-dcpr bootstrap init-dcpr-requests
+   docker exec -ti emc-dcpr_ckan-web_1 poetry run ckan --config docker/ckan-test-settings.ini db upgrade -p dalrrd_emc_dcpr
    ```
 
 1. Run the tests with `pytest`. We use markers to differentiate between unit and integration tests. Run them like this:

--- a/README.md
+++ b/README.md
@@ -316,7 +316,19 @@ docker volume rm emc-dcpr_datastore-db-data
 ```
 
 
-#### Bootstrap ckanext-spatial extension
+#### Bootstrap additional CKAN extensions
+
+Run the following command in order to have additional extensions correctly get their
+DB tables created:
+
+```bash
+docker exec -ti emc-dcpr_ckan-web_1 poetry run ckan spatial initdb
+docker exec -ti emc-dcpr_ckan-web_1 poetry run ckan harvester initdb
+docker exec -ti emc-dcpr_ckan-web_1 poetry run ckan pages initdb
+```
+
+
+##### NOTES
 
 The ckanext-spatial extension takes care of its own bootstrapping and will create any database tables
 automatically. However, you may want to bootstrap explicitly. If so, run:
@@ -325,24 +337,12 @@ automatically. However, you may want to bootstrap explicitly. If so, run:
 docker exec -ti emc-dcpr_ckan-web_1 poetry run ckan spatial initdb
 ```
 
-
-##### Note
-
-The spatial extension documentation seems to be outdated when it comes to
+Additionally, the spatial extension documentation seems to be outdated when it comes to
 running its custom CKAN CLI commands. Instead
 of the older `paster`-based incantation, they should rather be ran like:
 
 ```sh
 poetry run ckan spatial <command>
-```
-
-#### Bootstrap the harvesting extension
-
-Run the following command in order to have the harvesting tables be created
-on the CKAN DB:
-
-```bash
-docker exec -ti emc-dcpr_ckan-web_1 poetry run ckan harvester initdb
 ```
 
 

--- a/ckanext/dalrrd_emc_dcpr/cli/__init__.py
+++ b/ckanext/dalrrd_emc_dcpr/cli/__init__.py
@@ -129,6 +129,25 @@ class _CkanBootstrapDCPRRequest:
         return result
 
 
+@dataclasses.dataclass
+class _CkanExtBootstrapPage:
+    name: str
+    content: str
+    private: bool
+    org_id: typing.Optional[str] = None
+    order: typing.Optional[str] = ""
+    page_type: typing.Optional[str] = "page"
+    user_id: typing.Optional[str] = None
+
+    def to_data_dict(self) -> typing.Dict:
+        result = {}
+        for name, value in vars(self).items():
+            if value is not None:
+                result[name] = _to_data_dict(value)
+        result["title"] = self.name.capitalize()
+        return result
+
+
 def _to_data_dict(value):
     if isinstance(value, str):
         result = value

--- a/ckanext/dalrrd_emc_dcpr/cli/_bootstrap_data.py
+++ b/ckanext/dalrrd_emc_dcpr/cli/_bootstrap_data.py
@@ -1,6 +1,12 @@
 import typing
 
-from . import _CkanBootstrapOrganization
+from ckan.plugins import toolkit
+
+from . import _CkanBootstrapOrganization, _CkanExtBootstrapPage
+
+_staff_org_name = toolkit.config.get(
+    "ckan.dalrrd_emc_dcpr.portal_staff_organization_name", "SASDI EMC staff"
+)
 
 
 SASDI_ORGANIZATIONS: typing.Final[typing.List[_CkanBootstrapOrganization]] = [
@@ -29,5 +35,42 @@ SASDI_ORGANIZATIONS: typing.Final[typing.List[_CkanBootstrapOrganization]] = [
             "subcommittees developed a Programme of Work to guide the work to be "
             "done by the CSI in achieving the objectives of SASDI."
         ),
+    ),
+    _CkanBootstrapOrganization(
+        title=_staff_org_name,
+        description=(
+            f"The {_staff_org_name} organization is responsible for the maintenance of "
+            f"the static contents for the EMC portal"
+        ),
+    ),
+]
+
+PORTAL_PAGES: typing.Final[typing.List[_CkanExtBootstrapPage]] = [
+    _CkanExtBootstrapPage(
+        name="help",
+        content=(
+            "This is the EMC help section. It contains resources to help you use the "
+            "SASDI EMC effectively\n\n"
+            "- [Frequently Asked Questions](frequently-asked-questions)"
+        ),
+        private=False,
+        order="3",
+    ),
+    _CkanExtBootstrapPage(
+        name="about",
+        content=("Welcome to the SASDI Electronic Metadata Catalogue"),
+        private=False,
+        order="4",
+    ),
+    _CkanExtBootstrapPage(
+        name="frequently-asked-questions",
+        content=(
+            "This is the default FAQ section\n\n"
+            "1. What is this?\n\n"
+            "    Its a metadata catalogue\n\n"
+            "2. Can I link between pages?\n\n"
+            "    It seems so: here is a link to the [help](help) page"
+        ),
+        private=False,
     ),
 ]

--- a/ckanext/dalrrd_emc_dcpr/cli/commands.py
+++ b/ckanext/dalrrd_emc_dcpr/cli/commands.py
@@ -33,7 +33,7 @@ from ..constants import (
 )
 from ..email_notifications import get_and_send_notifications_for_all_users
 
-from ._bootstrap_data import SASDI_ORGANIZATIONS
+from ._bootstrap_data import PORTAL_PAGES, SASDI_ORGANIZATIONS
 from ._sample_datasets import (
     SAMPLE_DATASET_TAG,
     generate_sample_datasets,
@@ -262,6 +262,52 @@ def create_iso_topic_categories():
                     ),
                     fg=_INFO_COLOR,
                 )
+    click.secho("Done!", fg=_SUCCESS_COLOR)
+
+
+@bootstrap.command()
+def create_pages():
+    """Create default pages"""
+    click.secho("Creating default pages...")
+    user = toolkit.get_action("get_site_user")({"ignore_auth": True}, {})
+    context = {"user": user["name"]}
+    existing_pages = toolkit.get_action("ckanext_pages_list")(
+        context=context, data_dict={}
+    )
+    existing_page_names = [p["name"] for p in existing_pages]
+    for page in PORTAL_PAGES:
+        if page.name not in existing_page_names:
+            click.secho(f"Creating page {page.name!r}...", fg=_INFO_COLOR)
+            toolkit.get_action("ckanext_pages_update")(
+                context=context, data_dict=page.to_data_dict()
+            )
+        else:
+            click.secho(
+                f"Page {page.name!r} already exists, skipping...", fg=_INFO_COLOR
+            )
+    click.secho("Done!", fg=_SUCCESS_COLOR)
+
+
+@delete_data.command()
+def delete_pages():
+    """Delete default pages"""
+    click.secho("Deleting default pages...")
+    user = toolkit.get_action("get_site_user")({"ignore_auth": True}, {})
+    context = {"user": user["name"]}
+    existing_pages = toolkit.get_action("ckanext_pages_list")(
+        context=context, data_dict={}
+    )
+    existing_page_names = [p["name"] for p in existing_pages]
+    for page in PORTAL_PAGES:
+        if page.name in existing_page_names:
+            click.secho(f"Deleting page {page.name!r}...", fg=_INFO_COLOR)
+            toolkit.get_action("ckanext_pages_delete")(
+                context=context, data_dict={"page": page.name}
+            )
+        else:
+            click.secho(
+                f"Page {page.name!r} does not exist, skipping...", fg=_INFO_COLOR
+            )
     click.secho("Done!", fg=_SUCCESS_COLOR)
 
 

--- a/ckanext/dalrrd_emc_dcpr/logic/auth/pages.py
+++ b/ckanext/dalrrd_emc_dcpr/logic/auth/pages.py
@@ -1,0 +1,112 @@
+"""Custom auth functions for ckanext-pages
+
+These are used to control which users are allowed to edit new pages on the portal
+
+"""
+
+import logging
+import typing
+
+import ckan.plugins.toolkit as toolkit
+from ckanext.pages import db as pages_db
+
+
+logger = logging.getLogger(__name__)
+
+
+@toolkit.chained_auth_function
+def authorize_edit_page(
+    next_auth: typing.Callable,
+    context: typing.Dict,
+    data_dict: typing.Optional[typing.Dict] = None,
+) -> typing.Dict:
+    """Check whether user should be allowed to edit pages
+
+    This auth function customizes the default behavior of ckanext-pages. Where the
+    default is to only allow sysadmins to edit a page, we instead check if they are
+    members of the special portal staff group.
+
+    As a result of this override behavior we do not call `next_auth` here - otherwise
+    the default ckanext-pages auth function would be called last and it would
+    end up enforcing the default behavior (i.e. only allow sysadmins to edit a page).
+
+    """
+
+    result = {"success": False}
+    user = context["auth_user_obj"]
+    if toolkit.h["emc_user_is_staff_member"](user.id):
+        result["success"] = True
+    else:
+        result["msg"] = toolkit._("You are not authorized to edit pages")
+    return result
+
+
+@toolkit.chained_auth_function
+def authorize_delete_page(
+    next_auth: typing.Callable,
+    context: typing.Dict,
+    data_dict: typing.Optional[typing.Dict] = None,
+) -> typing.Dict:
+    """Check whether user should be allowed to delete pages
+
+    This auth function customizes the default behavior of ckanext-pages. Where the
+    default is to only allow sysadmins to delete a page, we instead check if they are
+    members of the special portal staff group.
+
+    As a result of this override behavior we do not call `next_auth` here - otherwise
+    the default ckanext-pages auth function would be called last and it would
+    end up enforcing the default behavior.
+
+    """
+
+    result = {"success": False}
+    user = context["auth_user_obj"]
+    if toolkit.h["emc_user_is_staff_member"](user.id):
+        result["success"] = True
+    else:
+        result["msg"] = toolkit._("You are not authorized to delete pages")
+    return result
+
+
+@toolkit.chained_auth_function
+@toolkit.auth_allow_anonymous_access
+def authorize_show_page(
+    next_auth: typing.Callable,
+    context: typing.Dict,
+    data_dict: typing.Optional[typing.Dict] = None,
+) -> typing.Dict:
+    """Check whether user should be allowed to view a page
+
+    This auth function customized the default behavior of ckanext-pages. Where the
+    default is to check if a page is public and if not only allow access to sysadmins,
+    we want members of the special portal staff group to also be able to access private
+    pages.
+
+    As a result of this override behavior we may not call `next_auth` here - otherwise
+    the default ckanext-pages auth function would be called last and it would
+    end up enforcing the default behavior.
+
+    """
+
+    data_dict = dict(data_dict) if data_dict is not None else {}
+    org_id = data_dict.get("org_id")
+    page = data_dict.get("page")
+    out = pages_db.Page.get(group_id=org_id, name=page)
+    result = {"success": False}
+    if out:
+        if org_id:  # check membership of the user by calling original method
+            result = next_auth(context, data_dict)
+        else:  # universal page, lets see if page is private and/or if user is staff
+            if out.private:  # user can only see it if it is from staff
+                user = context["auth_user_obj"]
+                if toolkit.h["emc_user_is_staff_member"](user.id):
+                    result["success"] = True
+                else:
+                    result["msg"] = toolkit._(
+                        "You are not authorized to access page %s" % page
+                    )
+            else:  # everyone can see it
+                result["success"] = True
+    else:
+        result["msg"] = toolkit._("Page %s not found") % page
+    return result

--- a/ckanext/dalrrd_emc_dcpr/plugin.py
+++ b/ckanext/dalrrd_emc_dcpr/plugin.py
@@ -24,6 +24,7 @@ from .logic import (
 )
 from .logic.auth import dcpr as dcpr_auth
 from .logic.auth import ckan as ckan_auth
+from .logic.auth import pages as ckanext_pages_auth
 
 logger = logging.getLogger(__name__)
 
@@ -113,6 +114,9 @@ class DalrrdEmcDcprPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
             "package_patch": ckan_auth.package_patch,
             "dcpr_request_create_auth": dcpr_auth.dcpr_request_create_auth,
             "dcpr_request_list_auth": dcpr_auth.dcpr_request_list_auth,
+            "ckanext_pages_update": ckanext_pages_auth.authorize_edit_page,
+            "ckanext_pages_delete": ckanext_pages_auth.authorize_delete_page,
+            "ckanext_pages_show": ckanext_pages_auth.authorize_show_page,
         }
 
     def get_actions(self) -> typing.Dict[str, typing.Callable]:
@@ -143,12 +147,14 @@ class DalrrdEmcDcprPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
             "dalrrd_emc_dcpr_default_spatial_search_extent": partial(
                 helpers.get_default_spatial_search_extent, 0.001
             ),
+            "emc_build_nav_main": helpers.build_pages_nav_main,
             "emc_default_bounding_box": helpers.get_default_bounding_box,
             "emc_convert_geojson_to_bounding_box": helpers.convert_geojson_to_bbox,
             "emc_sasdi_themes": helpers.get_sasdi_themes,
             "emc_iso_topic_categories": helpers.get_iso_topic_categories,
             "emc_show_version": helpers.helper_show_version,
             "emc_user_is_org_member": helpers.user_is_org_member,
+            "emc_user_is_staff_member": helpers.user_is_staff_member,
         }
 
     def get_blueprint(self) -> typing.List[Blueprint]:

--- a/ckanext/dalrrd_emc_dcpr/templates/header.html
+++ b/ckanext/dalrrd_emc_dcpr/templates/header.html
@@ -16,10 +16,12 @@
       {% block header_site_navigation %}
         <ul class="nav navbar-nav container-fluid-nav text-center">
             {% block header_site_navigation_tabs %}
-                <li class="nav-item"><a href="{{ h.url_for('dataset.search') }}">Datasets</a></li>
-                <li class="nav-item"><a href="{{ h.url_for('organization.index') }}">Organizations</a></li>
-                <li class="nav-item"><a href="#">Data Capture</a></li>
-	    {% endblock %}
+                {{ h.emc_build_nav_main(
+                    ('dataset.search', _('Datasets')),
+                    ('organization.index', _('Organizations')),
+                    ('group.index', _('Groups')),
+                    ('home.about', _('About')) ) }}
+            {% endblock %}
         </ul>
       {% endblock %}
       <ul class="nav navbar-nav navbar-right">
@@ -66,13 +68,33 @@
                           </a>
                         </li>
                     {% endif %}
+                    {#
+                    This next section has been borrowed and adapted from ckanext-pages header.html template. One
+                    notable difference is that we only show the pages-related nav items if the current user is allowed
+                    to modify them. This means that we need to provide means for these contents to be visible elsewhere
+                    like for example providing link to them via the main nav.
+                    #}
+                    {% if h.check_access('ckanext_pages_update') %}
+                        <li>
+                            <a href="{{ h.url_for('pages_index') }}" title="{{ _('Pages') }}">
+                                <i class="fa fa-file icon-file" aria-hidden="true"></i>
+                                <span class="text">{{ _('Pages') }}</span>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="{{ h.url_for('pages.blog_index' if h.ckan_version().split('.')[1] | int >= 9 else 'blog_index') }}" title="{{ _('Blog') }}">
+                                <i class="fa fa-pencil icon-pencil"></i>
+                                <span class="text">{{ _('Blog') }}</span>
+                            </a>
+                        </li>
+                    {% endif %}
                     {% block header_account_log_out_link %}
-                    <li>
-                      <a href="{{ h.url_for('user.logout') }}" title="{{ _('Log out') }}">
-                        <i class="fa fa-sign-out" aria-hidden="true"></i>
-                        <span class="text">{{ _('Log out') }}</span>
-                      </a>
-                    </li>
+                        <li>
+                            <a href="{{ h.url_for('user.logout') }}" title="{{ _('Log out') }}">
+                                <i class="fa fa-sign-out" aria-hidden="true"></i>
+                                <span class="text">{{ _('Log out') }}</span>
+                            </a>
+                        </li>
                     {% endblock %}
                 </ul>
 

--- a/docker/ckan-dev-settings.ini
+++ b/docker/ckan-dev-settings.ini
@@ -141,6 +141,7 @@ ckan.plugins = stats
                shp_view
                csw_harvester
                scheming_datasets
+               pages
                dalrrd_emc_dcpr
 
 # Define which views should be created by default
@@ -261,6 +262,12 @@ ckan.jobs.timeout = 180
 scheming.dataset_schemas = ckanext.dalrrd_emc_dcpr:scheming/dataset_schema.yaml
 scheming.presets = ckanext.dalrrd_emc_dcpr:scheming/presets.yaml ckanext.scheming:presets.json
 
+## ckanext-pages settings
+# We provide our own about page, which is editable in the frontend. As such we disable the default CKAN about
+ckanext.pages.about_menu = False
+ckanext.pages.group_menu = False
+
+
 ## dalrrd_emc_dcpr settings
 ckan.dalrrd_emc_dcpr.default_spatial_search_extent =
     {
@@ -290,6 +297,8 @@ ckan.dalrrd_emc_dcpr.sasdi_themes =
     Land Use
     Social Statistics
     Transport
+
+ckan.dalrrd_emc_dcpr.portal_staff_organization_name = SASDI EMC staff
 
 ## Logging configuration
 [loggers]

--- a/poetry.lock
+++ b/poetry.lock
@@ -192,6 +192,25 @@ reference = "v1.3.4"
 resolved_reference = "694a8cc139f42dce4c38eca3cf69b24ff3df347b"
 
 [[package]]
+name = "ckanext-pages"
+version = "0.3.3"
+description = "Basic CMS extension for ckan"
+category = "main"
+optional = false
+python-versions = "*"
+develop = false
+
+[package.dependencies]
+ckantoolkit = "*"
+six = "*"
+
+[package.source]
+type = "git"
+url = "https://github.com/ckan/ckanext-pages.git"
+reference = "v0.3.4"
+resolved_reference = "79d9740ffa048ac25ab94de0a5209db0411d0c42"
+
+[[package]]
 name = "ckanext-scheming"
 version = "2.1.0"
 description = ""
@@ -1298,7 +1317,7 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "26ffc9e1288f8db56a453ccca9afbda6930cebb9396462ae593ed7fea52aaa1e"
+content-hash = "4726d886266879e9f1fa12d7edd53dc352296b8e8beab09feb88cf4f0034dd67"
 
 [metadata.files]
 alembic = [
@@ -1401,6 +1420,7 @@ ckanapi = [
 ]
 ckanext-geoview = []
 ckanext-harvest = []
+ckanext-pages = []
 ckanext-scheming = []
 ckanext-spatial = []
 ckantoolkit = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,7 @@ ckanext-geoview = {git = "https://github.com/ckan/ckanext-geoview.git", rev = "v
 gunicorn = "^20.1.0"
 Flask-DebugToolbar = "^0.11.0"
 ckanext-scheming = {git = "https://github.com/ckan/ckanext-scheming.git", rev = "79270b1"}
+ckanext-pages = {git = "https://github.com/ckan/ckanext-pages.git", rev = "v0.3.4"}
 
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
This commit introduces [ckanext-pages](https://github.com/ckan/ckanext-pages) and presents initial customization of it to suit our needs.

It leverages ckanext-pages in order to allow both sysadmins and users of the new `SASDI emc staff` group to create and manage additional pages on the portal. Also included in this PR is an initial version of the `About` and `Help` sections, using this functionality.

fixes #128
fixes #120