### PR TITLE
Update DCPR request tests to run reliably

### DIFF
--- a/tests/test_integration_dcpr_requests.py
+++ b/tests/test_integration_dcpr_requests.py
@@ -14,7 +14,7 @@ from ckanext.dalrrd_emc_dcpr.cli._sample_dcpr_requests import SAMPLE_REQUESTS
 
 pytestmark = pytest.mark.integration
 
-dcpr_request_test_uuid = uuid.uuid4()
+
 @pytest.mark.parametrize(
     "request_id, name, user_available, user_logged",
     [
@@ -34,19 +34,11 @@ dcpr_request_test_uuid = uuid.uuid4()
             id="request-can-not-be-added-integrity-error",
         ),
         pytest.param(
-            dcpr_request_test_uuid,
+            uuid.uuid4(),
             "request_3",
             True,
             True,
             id="request-can-be-added-custom-request-id",
-        ),
-        pytest.param(
-            dcpr_request_test_uuid,
-            "request_4",
-            True,
-            True,
-            marks=pytest.mark.raises(exception=logic.ValidationError),
-            id="request-can-not-be-added-validation-error",
         ),
     ],
 )

--- a/tests/test_integration_dcpr_requests.py
+++ b/tests/test_integration_dcpr_requests.py
@@ -14,7 +14,7 @@ from ckanext.dalrrd_emc_dcpr.cli._sample_dcpr_requests import SAMPLE_REQUESTS
 
 pytestmark = pytest.mark.integration
 
-
+dcpr_request_test_uuid = uuid.uuid4()
 @pytest.mark.parametrize(
     "request_id, name, user_available, user_logged",
     [
@@ -34,14 +34,14 @@ pytestmark = pytest.mark.integration
             id="request-can-not-be-added-integrity-error",
         ),
         pytest.param(
-            uuid.UUID("1d2b018d-3e0b-479c-938c-582376f3cd4a"),
+            dcpr_request_test_uuid,
             "request_3",
             True,
             True,
             id="request-can-be-added-custom-request-id",
         ),
         pytest.param(
-            uuid.UUID("1d2b018d-3e0b-479c-938c-582376f3cd4a"),
+            dcpr_request_test_uuid,
             "request_4",
             True,
             True,

--- a/tests/test_integration_dcpr_requests.py
+++ b/tests/test_integration_dcpr_requests.py
@@ -15,6 +15,8 @@ from ckanext.dalrrd_emc_dcpr.cli._sample_dcpr_requests import SAMPLE_REQUESTS
 pytestmark = pytest.mark.integration
 
 dcpr_request_test_uuid = uuid.uuid4()
+
+
 @pytest.mark.parametrize(
     "request_id, name, user_available, user_logged",
     [

--- a/tests/test_integration_dcpr_requests.py
+++ b/tests/test_integration_dcpr_requests.py
@@ -15,8 +15,6 @@ from ckanext.dalrrd_emc_dcpr.cli._sample_dcpr_requests import SAMPLE_REQUESTS
 pytestmark = pytest.mark.integration
 
 dcpr_request_test_uuid = uuid.uuid4()
-
-
 @pytest.mark.parametrize(
     "request_id, name, user_available, user_logged",
     [


### PR DESCRIPTION
Initially intended to update the duplicate check on the DCPR request creation tests, but now removes the duplicate check entry, based on the discussion with @ricardogsilva as it doesn't add much value for it to be in the tests.