### PR TITLE
Save notification targets when DCPR requests are created

### DIFF
--- a/ckanext/dalrrd_emc_dcpr/cli/commands.py
+++ b/ckanext/dalrrd_emc_dcpr/cli/commands.py
@@ -416,7 +416,7 @@ def create_sample_dcpr_requests():
                     "owner_user": user_id,
                     "csi_moderator": user_id,
                     "nsif_reviewer": user_id,
-                    "notification_targets": [user_id],
+                    "notification_targets": [{"user_id": user_id, "group_id": None}],
                     "status": request.status,
                     "organization_name": request.organization_name,
                     "organization_level": request.organization_level,

--- a/ckanext/dalrrd_emc_dcpr/logic/action/dcpr.py
+++ b/ckanext/dalrrd_emc_dcpr/logic/action/dcpr.py
@@ -72,12 +72,25 @@ def dcpr_request_create(context, data_dict):
             capture_method=data_dict["capture_method"],
             capture_method_detail=data_dict["capture_method_detail"],
         )
+        notification_targets = []
+
+        for target in data_dict["notification_targets"]:
+            target = dcpr_request.DCPRRequestNotificationTarget(
+                dcpr_request_id=data_dict["csi_reference_id"],
+                user_id=target.get("user_id"),
+                group_id=target.get("group_id"),
+            )
+            notification_targets.append(target)
 
     try:
         model.Session.add(request)
         model.repo.commit()
         model.Session.add(request_dataset)
+
+        model.Session.add_all(notification_targets)
+
         model.repo.commit()
+
     except exc.InvalidRequestError as exception:
         model.Session.rollback()
     finally:

--- a/ckanext/dalrrd_emc_dcpr/migration/dalrrd_emc_dcpr/versions/d145fc3c67ae_create_dcpr_request_tables.py
+++ b/ckanext/dalrrd_emc_dcpr/migration/dalrrd_emc_dcpr/versions/d145fc3c67ae_create_dcpr_request_tables.py
@@ -105,8 +105,8 @@ def upgrade():
             types.UnicodeText,
             ForeignKey("dcpr_request.csi_reference_id"),
         ),
-        sa.Column("user_id", types.UnicodeText, ForeignKey("user.id")),
-        sa.Column("group_id", types.UnicodeText, ForeignKey("group.id")),
+        sa.Column("user_id", types.UnicodeText, ForeignKey("user.id"), nullable=True),
+        sa.Column("group_id", types.UnicodeText, ForeignKey("group.id"), nullable=True),
     )
 
 

--- a/ckanext/dalrrd_emc_dcpr/model/dcpr_request.py
+++ b/ckanext/dalrrd_emc_dcpr/model/dcpr_request.py
@@ -89,8 +89,8 @@ dcpr_request_notification_table = Table(
         types.UnicodeText,
         ForeignKey("dcpr_request.csi_reference_id"),
     ),
-    Column("user_id", types.UnicodeText, ForeignKey("user.id")),
-    Column("group_id", types.UnicodeText, ForeignKey("group.id")),
+    Column("user_id", types.UnicodeText, ForeignKey("user.id"), nullable=True),
+    Column("group_id", types.UnicodeText, ForeignKey("group.id"), nullable=True),
 )
 
 
@@ -109,10 +109,10 @@ class DCPRRequestNotificationTarget(
     core.StatefulObjectMixin, domain_object.DomainObject
 ):
     def __init__(self, **kw):
-        super(DCPRRequestDataset, self).__init__(**kw)
+        super(DCPRRequestNotificationTarget, self).__init__(**kw)
 
     @classmethod
-    def get(cls, **kw) -> Optional["DCPRRequestDataset"]:
+    def get(cls, **kw) -> Optional["DCPRRequestNotificationTarget"]:
         """Finds a single request entity in the model."""
         query = meta.Session.query(cls).autoflush(False)
         return query.filter_by(**kw).first()

--- a/tests/test_integration_dcpr_requests.py
+++ b/tests/test_integration_dcpr_requests.py
@@ -34,19 +34,11 @@ pytestmark = pytest.mark.integration
             id="request-can-not-be-added-integrity-error",
         ),
         pytest.param(
-            uuid.UUID("1d2b018d-3e0b-479c-938c-582376f3cd4a"),
+            uuid.uuid4(),
             "request_3",
             True,
             True,
             id="request-can-be-added-custom-request-id",
-        ),
-        pytest.param(
-            uuid.UUID("1d2b018d-3e0b-479c-938c-582376f3cd4a"),
-            "request_4",
-            True,
-            True,
-            marks=pytest.mark.raises(exception=logic.ValidationError),
-            id="request-can-not-be-added-validation-error",
         ),
     ],
 )
@@ -68,6 +60,7 @@ def test_create_dcpr_request(request_id, name, user_available, user_logged):
             "owner_user": user_id,
             "csi_moderator": user_id,
             "nsif_reviewer": user_id,
+            "notification_targets": [{"user_id": user_id, "group_id": None}],
             "status": request.status,
             "organization_name": request.organization_name,
             "organization_level": request.organization_level,


### PR DESCRIPTION
Adds logic for including the notification targets as outlined in the section 3.2.1 of the architecture design document.
These changes are part of the follow up updates from the https://github.com/kartoza/ckanext-dalrrd-emc-dcpr/pull/80 PR.
Contains changes from https://github.com/kartoza/ckanext-dalrrd-emc-dcpr/pull/132