### PR TITLE
Add crisp JS snippet to base template

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ guide to install CKAN, then follow the below steps:
    ```
 
 
-# Migrations
+## Migrations
 
 Run the extension's specific migrations using the following commands to upgrade and downgrade
 the ckan database respectively.
@@ -530,3 +530,10 @@ To run any of the above docker commands once this is deployed into Kubernetes yo
   1. Get the pod name: `kubectl get pods --namespace=emc-dcpr`, it should look like `ckan-<randon string>`
   2. Run `kubectl exec -it <pod name> --namespace=emc-dcpr -- bash`
   3. Or an all in one: `kubectl exec -it "$(kubectl get pods --namespace=emc-dcpr | grep Running | grep ckan- | grep -v postgis | cut -d' ' -f1)" --namespace=emc-dcpr -- bash`
+
+
+## User feedback
+
+The system is using the [crisp] chatbox to allow gathering feedback from users. Configure it at the crisp website
+
+[crisp]: https://crisp.chat/en/

--- a/ckanext/dalrrd_emc_dcpr/templates/base.html
+++ b/ckanext/dalrrd_emc_dcpr/templates/base.html
@@ -6,3 +6,10 @@
     {% asset 'ckanext-dalrrdemcdcpr/dalrrd-emc-dcpr-css' %}
 
 {% endblock %}
+
+{% block scripts %}
+    {{ super() }}
+    <script type="text/javascript">
+        window.$crisp=[];window.CRISP_WEBSITE_ID="b725612e-5df8-4a32-b7a4-e13484d28435";(function(){d=document;s=d.createElement("script");s.src="https://client.crisp.chat/l.js";s.async=1;d.getElementsByTagName("head")[0].appendChild(s);})();
+    </script>
+{% endblock %}


### PR DESCRIPTION
This PR integrates the [crisp] textbox into the system. It provides a modern client for letting users ask questions about a website.


fixes #141

[crisp]: https://crisp.chat/en/