### PR TITLE
Add recently modified datasets to landing page

### DIFF
--- a/ckanext/dalrrd_emc_dcpr/helpers.py
+++ b/ckanext/dalrrd_emc_dcpr/helpers.py
@@ -186,7 +186,12 @@ def build_pages_nav_main(*args):
 def get_featured_datasets():
     search_action = toolkit.get_action("package_search")
     result = search_action(data_dict={"q": "featured:true", "rows": 5})
-    logger.debug(f"inside get_featured_datasets helper: {result=}")
+    return result["results"]
+
+
+def get_recently_modified_datasets():
+    search_action = toolkit.get_action("package_search")
+    result = search_action(data_dict={"sort": "metadata_modified desc", "rows": 5})
     return result["results"]
 
 

--- a/ckanext/dalrrd_emc_dcpr/plugin.py
+++ b/ckanext/dalrrd_emc_dcpr/plugin.py
@@ -156,6 +156,7 @@ class DalrrdEmcDcprPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
             "emc_user_is_org_member": helpers.user_is_org_member,
             "emc_user_is_staff_member": helpers.user_is_staff_member,
             "emc_get_featured_datasets": helpers.get_featured_datasets,
+            "emc_get_recently_modified_datasets": helpers.get_recently_modified_datasets,
         }
 
     def get_blueprint(self) -> typing.List[Blueprint]:

--- a/ckanext/dalrrd_emc_dcpr/templates/home/index.html
+++ b/ckanext/dalrrd_emc_dcpr/templates/home/index.html
@@ -126,6 +126,8 @@
         </div>
         <div class="col-lg-6 index-datasets">
             <h2 class="mb-5 section-title">Recent Datasets</h2>
+            {% set recent_datasets = h.emc_get_recently_modified_datasets() %}
+            {{ h.snippet('snippets/package_list.html', packages=recent_datasets) }}
         </div>
     </div>
 </div>


### PR DESCRIPTION
This PR populates the _recent datasets_ section of the landing page with... recently modified datasets

fixes #138