### PR TITLE
Removed cli command for initialization of dcpr requests models

### DIFF
--- a/ckanext/dalrrd_emc_dcpr/cli/commands.py
+++ b/ckanext/dalrrd_emc_dcpr/cli/commands.py
@@ -24,7 +24,7 @@ from ckan import model
 from ckan.lib.navl import dictization_functions
 
 # from ckan.lib.email_notifications import get_and_send_notifications_for_all_users
-from ckanext.dalrrd_emc_dcpr.model.dcpr_request import DCPRRequest, init_request_tables
+from ckanext.dalrrd_emc_dcpr.model.dcpr_request import DCPRRequest
 
 from ..constants import (
     ISO_TOPIC_CATEGOY_VOCABULARY_NAME,
@@ -425,12 +425,6 @@ def delete_sasdi_organizations():
                 fg=_INFO_COLOR,
             )
     click.secho(f"Done!", fg=_SUCCESS_COLOR)
-
-
-@bootstrap.command()
-def init_dcpr_requests():
-    """Initialize database with the DCPR request tables"""
-    init_request_tables()
 
 
 @dalrrd_emc_dcpr.group()

--- a/ckanext/dalrrd_emc_dcpr/model/dcpr_request.py
+++ b/ckanext/dalrrd_emc_dcpr/model/dcpr_request.py
@@ -159,24 +159,6 @@ class DCPRRequest(core.StatefulObjectMixin, domain_object.DomainObject):
         return targets
 
 
-def init_request_tables():
-    if not dcpr_request_table.exists():
-        log.debug("Creating DCPR request table")
-        dcpr_request_table.create()
-    else:
-        log.debug("DCPR request table already exists")
-    if not dcpr_request_dataset_table.exists():
-        log.debug("Creating DCPR request dataset table")
-        dcpr_request_dataset_table.create()
-    else:
-        log.debug("DCPR request dataset table already exists")
-    if not dcpr_request_notification_table.exists():
-        log.debug("Creating DCPR request notification target table")
-        dcpr_request_notification_table.create()
-    else:
-        log.debug("DCPR request notification target table already exists")
-
-
 meta.mapper(DCPRRequest, dcpr_request_table)
 meta.mapper(DCPRRequestNotificationTarget, dcpr_request_notification_table)
 meta.mapper(DCPRRequestDataset, dcpr_request_dataset_table)


### PR DESCRIPTION
Now that we have migrations for the dalrrd-emc-dcpr extension models working as expected, this PR removes the cli command that was added for the intent of creating dcpr requests models.