### PR TITLE
Implement dataset maintenance requests

### DIFF
--- a/ckanext/dalrrd_emc_dcpr/blueprints/emc.py
+++ b/ckanext/dalrrd_emc_dcpr/blueprints/emc.py
@@ -12,13 +12,8 @@ emc_blueprint = Blueprint(
 
 @emc_blueprint.route("/request_dataset_maintenance/<dataset_id>")
 def request_dataset_maintenance(dataset_id):
-    logger.debug(f"{locals()=}")
-    logger.debug("Inside the emc request_package_maintenance view")
     toolkit.get_action("emc_request_dataset_maintenance")(
         data_dict={"pkg_id": dataset_id}
-    )
-    toolkit.get_action("follow_dataset")(
-        data_dict={"id": dataset_id},
     )
     toolkit.h["flash_notice"](
         toolkit._(

--- a/ckanext/dalrrd_emc_dcpr/blueprints/emc.py
+++ b/ckanext/dalrrd_emc_dcpr/blueprints/emc.py
@@ -14,10 +14,13 @@ emc_blueprint = Blueprint(
 def request_dataset_maintenance(dataset_id):
     logger.debug(f"{locals()=}")
     logger.debug("Inside the emc request_package_maintenance view")
-    toolkit.get_action("emc_request_dataset_modification")(
+    toolkit.get_action("emc_request_dataset_maintenance")(
         data_dict={"pkg_id": dataset_id}
     )
-    toolkit.h["flash_success"](
-        toolkit._("Sent notification to the dataset publishers!")
+    toolkit.h["flash_notice"](
+        toolkit._(
+            "Organization publishers will be notified of your request to perform "
+            "maintenance on this dataset!"
+        )
     )
     return toolkit.redirect_to("dataset.read", id=dataset_id)

--- a/ckanext/dalrrd_emc_dcpr/blueprints/emc.py
+++ b/ckanext/dalrrd_emc_dcpr/blueprints/emc.py
@@ -22,3 +22,21 @@ def request_dataset_maintenance(dataset_id):
         )
     )
     return toolkit.redirect_to("dataset.read", id=dataset_id)
+
+
+@emc_blueprint.route(
+    "/request_dataset_management/<string:dataset_id>/<string:management_command>"
+)
+def request_dataset_management(dataset_id, management_command):
+    action_name = {
+        "maintenance": "emc_request_dataset_maintenance",
+        "publication": "emc_request_dataset_publication",
+    }[management_command]
+    toolkit.get_action(action_name)(data_dict={"pkg_id": dataset_id})
+    toolkit.h["flash_notice"](
+        toolkit._(
+            "Organization publishers have been notified of your request. You are now "
+            "following the dataset and will be notified when it has been modified."
+        )
+    )
+    return toolkit.redirect_to("dataset.read", id=dataset_id)

--- a/ckanext/dalrrd_emc_dcpr/blueprints/emc.py
+++ b/ckanext/dalrrd_emc_dcpr/blueprints/emc.py
@@ -1,8 +1,5 @@
 import logging
-import typing
 
-from ckan import model
-from ckan.logic.schema import default_create_activity_schema
 from ckan.plugins import toolkit
 from flask import Blueprint
 
@@ -17,38 +14,9 @@ emc_blueprint = Blueprint(
 def request_dataset_maintenance(dataset_id):
     logger.debug(f"{locals()=}")
     logger.debug("Inside the emc request_package_maintenance view")
-    activity_schema = default_create_activity_schema()
-
-    # this is a hacky way to relax the activity type schema validation
-    to_remove = None
-    for index, validator in enumerate(activity_schema["activity_type"]):
-        if validator.__name__ == "activity_type_exists":
-            to_remove = validator
-            break
-    if to_remove:
-        activity_schema["activity_type"].remove(to_remove)
-    to_remove = None
-    for index, validator in enumerate(activity_schema["object_id"]):
-        if validator.__name__ == "object_id_validator":
-            to_remove = validator
-            break
-    if to_remove:
-        activity_schema["object_id"].remove(to_remove)
-
-    logger.debug(f"{activity_schema=}")
-    toolkit.get_action("activity_create")(
-        context={
-            "ignore_auth": True,
-            "schema": activity_schema,
-        },
-        data_dict={
-            "user_id": toolkit.g.userobj.id,
-            "object_id": dataset_id,
-            "activity_type": "requested modification",
-            "data": None,
-        },
+    toolkit.get_action("emc_request_dataset_modification")(
+        data_dict={"pkg_id": dataset_id}
     )
-
     toolkit.h["flash_success"](
         toolkit._("Sent notification to the dataset publishers!")
     )

--- a/ckanext/dalrrd_emc_dcpr/blueprints/emc.py
+++ b/ckanext/dalrrd_emc_dcpr/blueprints/emc.py
@@ -17,10 +17,13 @@ def request_dataset_maintenance(dataset_id):
     toolkit.get_action("emc_request_dataset_maintenance")(
         data_dict={"pkg_id": dataset_id}
     )
+    toolkit.get_action("follow_dataset")(
+        data_dict={"id": dataset_id},
+    )
     toolkit.h["flash_notice"](
         toolkit._(
-            "Organization publishers will be notified of your request to perform "
-            "maintenance on this dataset!"
+            "Organization publishers have been notified of your request. You are now "
+            "following the dataset and will be notified when it has been modified."
         )
     )
     return toolkit.redirect_to("dataset.read", id=dataset_id)

--- a/ckanext/dalrrd_emc_dcpr/blueprints/emc.py
+++ b/ckanext/dalrrd_emc_dcpr/blueprints/emc.py
@@ -1,6 +1,9 @@
 import logging
 import typing
 
+from ckan import model
+from ckan.logic.schema import default_create_activity_schema
+from ckan.plugins import toolkit
 from flask import Blueprint
 
 logger = logging.getLogger(__name__)
@@ -10,8 +13,43 @@ emc_blueprint = Blueprint(
 )
 
 
-@emc_blueprint.route("/request_package_maintenance")
-def request_package_maintenance():
+@emc_blueprint.route("/request_dataset_maintenance/<dataset_id>")
+def request_dataset_maintenance(dataset_id):
+    logger.debug(f"{locals()=}")
     logger.debug("Inside the emc request_package_maintenance view")
-    result = f"<h1>Hi from the EMC request package maintenance page!</h1>"
-    return result
+    activity_schema = default_create_activity_schema()
+
+    # this is a hacky way to relax the activity type schema validation
+    to_remove = None
+    for index, validator in enumerate(activity_schema["activity_type"]):
+        if validator.__name__ == "activity_type_exists":
+            to_remove = validator
+            break
+    if to_remove:
+        activity_schema["activity_type"].remove(to_remove)
+    to_remove = None
+    for index, validator in enumerate(activity_schema["object_id"]):
+        if validator.__name__ == "object_id_validator":
+            to_remove = validator
+            break
+    if to_remove:
+        activity_schema["object_id"].remove(to_remove)
+
+    logger.debug(f"{activity_schema=}")
+    toolkit.get_action("activity_create")(
+        context={
+            "ignore_auth": True,
+            "schema": activity_schema,
+        },
+        data_dict={
+            "user_id": toolkit.g.userobj.id,
+            "object_id": dataset_id,
+            "activity_type": "requested modification",
+            "data": None,
+        },
+    )
+
+    toolkit.h["flash_success"](
+        toolkit._("Sent notification to the dataset publishers!")
+    )
+    return toolkit.redirect_to("dataset.read", id=dataset_id)

--- a/ckanext/dalrrd_emc_dcpr/cli/commands.py
+++ b/ckanext/dalrrd_emc_dcpr/cli/commands.py
@@ -912,14 +912,34 @@ class AlembicWrapper:
 
 @dalrrd_emc_dcpr.command()
 @click.argument("job_name")
-@click.option("--job-arg", multiple=True)
+@click.option(
+    "--job-arg",
+    multiple=True,
+    help="Arguments for the job function. Can be provided multiple times",
+)
 @click.option(
     "--job-kwarg",
     multiple=True,
-    help="Provide each keyword argument as a colon-separated string of key_name:value",
+    help=(
+        "Provide each keyword argument as a colon-separated string of "
+        "key_name:value. This option can be provided multiple times"
+    ),
 )
 def test_background_job(job_name, job_arg, job_kwarg):
-    """Run background jobs synchronously"""
+    """Run background jobs synchronously
+
+    JOB_NAME is the name of the job function to be run. Look in the `jobs` module for
+    existing functions.
+
+    Example:
+
+    \b
+        ckan dalrrd-emc-dcpr test-background-job \\
+            notify_org_admins_of_dataset_maintenance_request \\
+            --job-arg=f1733d0c-5188-43b3-8039-d95efb76b4f5
+
+    """
+
     job_function = getattr(jobs, job_name, None)
     if job_function is not None:
         kwargs = {}

--- a/ckanext/dalrrd_emc_dcpr/constants.py
+++ b/ckanext/dalrrd_emc_dcpr/constants.py
@@ -1,3 +1,4 @@
+import enum
 import typing
 
 SASDI_THEMES_VOCABULARY_NAME: typing.Final[str] = "sasdi_themes"
@@ -25,3 +26,8 @@ ISO_TOPIC_CATEGORIES: typing.Final[typing.List[typing.Tuple[str, str]]] = [
     ("transportation", "Transportation"),
     ("utilitiesCommuinication", "Utilities, Communication"),
 ]
+
+
+class DatasetManagementActivityType(enum.Enum):
+    REQUEST_MAINTENANCE = "requested dataset maintenance"
+    REQUEST_PUBLICATION = "requested dataset publication"

--- a/ckanext/dalrrd_emc_dcpr/email_notifications.py
+++ b/ckanext/dalrrd_emc_dcpr/email_notifications.py
@@ -80,7 +80,9 @@ def send_notification(user, email_dict):
     import ckan.lib.mailer
 
     if not user.get("email"):
-        logger.debug(f"User {user!r} does not have an email address configured")
+        logger.debug(
+            f"User {user.get('name')!r} does not have an email address configured"
+        )
         # FIXME: Raise an exception.
         return
 
@@ -128,7 +130,7 @@ def _notifications_for_activities(activities, user_dict):
         "{n} new activities from {site_title}",
         len(activities),
     ).format(site_title=toolkit.config.get("ckan.site_title"), n=len(activities))
-    jinja_env = _get_jinja_env()
+    jinja_env = get_jinja_env()
     body_template = jinja_env.get_template("email_notifications/email_body.txt")
     rendered_body = body_template.render(
         activities=activities,
@@ -140,7 +142,7 @@ def _notifications_for_activities(activities, user_dict):
     return notifications
 
 
-def _get_jinja_env():
+def get_jinja_env():
     jinja_env = Environment(**jinja_extensions.get_jinja_env_options())
     jinja_env.install_gettext_callables(flask_ugettext, flask_ungettext, newstyle=True)
     # custom filters

--- a/ckanext/dalrrd_emc_dcpr/jobs.py
+++ b/ckanext/dalrrd_emc_dcpr/jobs.py
@@ -1,0 +1,66 @@
+"""Asynchronous jobs for EMC-DCPR"""
+
+import logging
+
+from ckan import model
+from ckan.plugins import toolkit
+
+from . import email_notifications
+
+logger = logging.getLogger(__name__)
+
+
+def test_job(*args, **kwargs):
+    logger.debug(f"inside test_job - {args=} {kwargs=}")
+
+
+def notify_org_admins_of_dataset_maintenance_request(activity_id: str):
+    activity = toolkit.get_action("activity_show")(
+        context={
+            "ignore_auth": True,
+            "user": None,  # CKAN expects there to be a user in context but does not actually use it
+        },
+        data_dict={"id": activity_id, "include_data": True},
+    )
+    dataset = activity.get("data", {}).get("package")
+    if dataset is not None:
+        org_id = dataset["owner_org"]
+        organization = toolkit.get_action("organization_show")(
+            context={"ignore_auth": True},
+            data_dict={
+                "id": org_id,
+                "include_users": True,
+            },
+        )
+        jinja_env = email_notifications.get_jinja_env()
+        subject_template = jinja_env.get_template(
+            "email_notifications/dataset_maintenance_request_subject.txt"
+        )
+        body_template = jinja_env.get_template(
+            "email_notifications/dataset_maintenance_request_body.txt"
+        )
+        for member in organization.get("users", []):
+            logger.debug(f"{member=}")
+            is_active = member.get("state") == "active"
+            is_org_admin = member.get("capacity") == "admin"
+            if is_active and is_org_admin:
+                user_obj = model.User.get(member["id"])
+                logger.debug(f"About to send a notification to {user_obj.name!r}...")
+                subject = subject_template.render(
+                    site_title=toolkit.config.get("site_title", "SASDI EMC")
+                )
+                body = body_template.render(
+                    organization=organization,
+                    user_obj=user_obj,
+                    dataset=dataset,
+                    h=toolkit.h,
+                    site_url=toolkit.config.get("ckan.site_url", ""),
+                )
+                email_notifications.send_notification(
+                    {
+                        "name": user_obj.name,
+                        "display_name": user_obj.display_name,
+                        "email": user_obj.email,
+                    },
+                    {"subject": subject, "body": body},
+                )

--- a/ckanext/dalrrd_emc_dcpr/logic/action/ckan.py
+++ b/ckanext/dalrrd_emc_dcpr/logic/action/ckan.py
@@ -1,6 +1,7 @@
 """Override of CKAN actions"""
 
 import logging
+import typing
 
 import ckan.plugins.toolkit as toolkit
 
@@ -31,6 +32,35 @@ def package_patch(original_action, context, data_dict):
     Intercepts the core `package_patch` action to check if package is being published.
     """
     return _package_publish_check(original_action, context, data_dict)
+
+
+def user_patch(context: typing.Dict, data_dict: typing.Dict) -> typing.Dict:
+    """Implements user_patch action, which is not available on CKAN
+
+    The `data_dict` parameter is expected to contain at least the `id` key, which
+    should hold the user's id or name
+
+    """
+
+    logger.debug(f"{locals()=}")
+    logger.debug("About to check access of user_update")
+    toolkit.check_access("user_update", context, data_dict)
+    logger.debug("After checking access of user_update")
+    show_context = {
+        "model": context["model"],
+        "session": context["session"],
+        "user": context["user"],
+        "auth_user_obj": context["auth_user_obj"],
+    }
+    user_dict = toolkit.get_action("user_show")(
+        show_context, data_dict={"id": context["user"]}
+    )
+    logger.debug(f"{user_dict=}")
+    patched = dict(user_dict)
+    patched.update(data_dict)
+    logger.debug(f"{patched=}")
+    update_action = toolkit.get_action("user_update")
+    return update_action(context, patched)
 
 
 def _package_publish_check(action, context, data):

--- a/ckanext/dalrrd_emc_dcpr/logic/action/emc.py
+++ b/ckanext/dalrrd_emc_dcpr/logic/action/emc.py
@@ -79,7 +79,7 @@ def request_dataset_maintenance(context: typing.Dict, data_dict: typing.Dict):
     dataset = toolkit.get_action("package_show")(
         data_dict={"id": data_dict.get("pkg_id")}
     )
-    toolkit.get_action("activity_create")(
+    activity = toolkit.get_action("activity_create")(
         context={
             "ignore_auth": True,
             "schema": activity_schema,
@@ -94,8 +94,6 @@ def request_dataset_maintenance(context: typing.Dict, data_dict: typing.Dict):
         },
     )
     toolkit.enqueue_job(
-        jobs.test_job,
-        args=["one", "two"],
-        kwargs={"this": "is it"},
-        title="My test job",
+        jobs.notify_org_admins_of_dataset_maintenance_request,
+        args=[activity["id"]],
     )

--- a/ckanext/dalrrd_emc_dcpr/logic/auth/ckan.py
+++ b/ckanext/dalrrd_emc_dcpr/logic/auth/ckan.py
@@ -14,7 +14,6 @@ def package_update(next_auth, context, data_dict=None):
     or site-wide sysadmins.
 
     """
-    logger.debug(f"inside package_update - {locals()=}")
 
     user = context["auth_user_obj"]
     if data_dict is None:

--- a/ckanext/dalrrd_emc_dcpr/logic/auth/emc.py
+++ b/ckanext/dalrrd_emc_dcpr/logic/auth/emc.py
@@ -15,12 +15,24 @@ def authorize_list_featured_datasets(
 def authorize_request_dataset_maintenance(
     context: typing.Dict, data_dict: typing.Dict
 ) -> typing.Dict:
+    return {
+        "success": _is_dataset_editor(context["auth_user_obj"], data_dict["pkg_id"])
+    }
+
+
+def authorize_request_dataset_publication(
+    context: typing.Dict, data_dict: typing.Dict
+) -> typing.Dict:
+    return {
+        "success": _is_dataset_editor(context["auth_user_obj"], data_dict["pkg_id"])
+    }
+
+
+def _is_dataset_editor(user_obj, dataset_id: str):
     """Checks if current user is an editor of the same org where dataset belongs."""
-    dataset = toolkit.get_action("package_show")(
-        data_dict={"id": data_dict.get("pkg_id")}
-    )
+    dataset = toolkit.get_action("package_show")(data_dict={"id": dataset_id})
     is_editor = toolkit.h["emc_user_is_org_member"](
-        dataset["owner_org"], context["auth_user_obj"], role="editor"
+        dataset["owner_org"], user_obj, role="editor"
     )
     result = {"success": False}
     if is_editor:

--- a/ckanext/dalrrd_emc_dcpr/logic/auth/emc.py
+++ b/ckanext/dalrrd_emc_dcpr/logic/auth/emc.py
@@ -1,8 +1,6 @@
 import logging
 import typing
 
-from ckan.plugins import toolkit
-
 logger = logging.getLogger(__name__)
 
 
@@ -10,3 +8,9 @@ def authorize_list_featured_datasets(
     context: typing.Dict, data_dict: typing.Optional[typing.Dict]
 ) -> typing.Dict:
     return {"success": True}
+
+
+def authorize_request_dataset_maintenance(
+    context: typing.Dict, data_dict: typing.Dict
+) -> typing.Dict:
+    return {"success": False}

--- a/ckanext/dalrrd_emc_dcpr/logic/auth/emc.py
+++ b/ckanext/dalrrd_emc_dcpr/logic/auth/emc.py
@@ -1,6 +1,8 @@
 import logging
 import typing
 
+from ckan.plugins import toolkit
+
 logger = logging.getLogger(__name__)
 
 
@@ -13,4 +15,14 @@ def authorize_list_featured_datasets(
 def authorize_request_dataset_maintenance(
     context: typing.Dict, data_dict: typing.Dict
 ) -> typing.Dict:
-    return {"success": False}
+    """Checks if current user is an editor of the same org where dataset belongs."""
+    dataset = toolkit.get_action("package_show")(
+        data_dict={"id": data_dict.get("pkg_id")}
+    )
+    is_editor = toolkit.h["emc_user_is_org_member"](
+        dataset["owner_org"], context["auth_user_obj"], role="editor"
+    )
+    result = {"success": False}
+    if is_editor:
+        result["success"] = True
+    return result

--- a/ckanext/dalrrd_emc_dcpr/plugin.py
+++ b/ckanext/dalrrd_emc_dcpr/plugin.py
@@ -25,6 +25,7 @@ from .logic import (
 from .logic.auth import ckan as ckan_auth
 from .logic.auth import pages as ckanext_pages_auth
 from .logic.auth import dcpr as dcpr_auth
+from .logic.auth import emc as emc_auth
 
 logger = logging.getLogger(__name__)
 
@@ -117,6 +118,9 @@ class DalrrdEmcDcprPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
             "ckanext_pages_update": ckanext_pages_auth.authorize_edit_page,
             "ckanext_pages_delete": ckanext_pages_auth.authorize_delete_page,
             "ckanext_pages_show": ckanext_pages_auth.authorize_show_page,
+            "request_dataset_maintenance": (
+                emc_auth.authorize_request_dataset_maintenance
+            ),
         }
 
     def get_actions(self) -> typing.Dict[str, typing.Callable]:
@@ -127,6 +131,7 @@ class DalrrdEmcDcprPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
             "dcpr_request_create": dcpr_actions.dcpr_request_create,
             "dcpr_request_list": dcpr_actions.dcpr_request_list,
             "emc_version": emc_actions.show_version,
+            "emc_request_dataset_maintenance": emc_actions.request_dataset_maintenance,
         }
 
     def get_validators(self) -> typing.Dict[str, typing.Callable]:

--- a/ckanext/dalrrd_emc_dcpr/plugin.py
+++ b/ckanext/dalrrd_emc_dcpr/plugin.py
@@ -132,6 +132,7 @@ class DalrrdEmcDcprPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
             "dcpr_request_list": dcpr_actions.dcpr_request_list,
             "emc_version": emc_actions.show_version,
             "emc_request_dataset_maintenance": emc_actions.request_dataset_maintenance,
+            "emc_user_patch": ckan_actions.user_patch,
         }
 
     def get_validators(self) -> typing.Dict[str, typing.Callable]:

--- a/ckanext/dalrrd_emc_dcpr/plugin.py
+++ b/ckanext/dalrrd_emc_dcpr/plugin.py
@@ -118,7 +118,7 @@ class DalrrdEmcDcprPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
             "ckanext_pages_update": ckanext_pages_auth.authorize_edit_page,
             "ckanext_pages_delete": ckanext_pages_auth.authorize_delete_page,
             "ckanext_pages_show": ckanext_pages_auth.authorize_show_page,
-            "request_dataset_maintenance": (
+            "emc_request_dataset_maintenance": (
                 emc_auth.authorize_request_dataset_maintenance
             ),
         }

--- a/ckanext/dalrrd_emc_dcpr/plugin.py
+++ b/ckanext/dalrrd_emc_dcpr/plugin.py
@@ -121,6 +121,9 @@ class DalrrdEmcDcprPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
             "emc_request_dataset_maintenance": (
                 emc_auth.authorize_request_dataset_maintenance
             ),
+            "emc_request_dataset_publication": (
+                emc_auth.authorize_request_dataset_publication
+            ),
         }
 
     def get_actions(self) -> typing.Dict[str, typing.Callable]:
@@ -132,6 +135,7 @@ class DalrrdEmcDcprPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
             "dcpr_request_list": dcpr_actions.dcpr_request_list,
             "emc_version": emc_actions.show_version,
             "emc_request_dataset_maintenance": emc_actions.request_dataset_maintenance,
+            "emc_request_dataset_publication": emc_actions.request_dataset_publication,
             "emc_user_patch": ckan_actions.user_patch,
         }
 

--- a/ckanext/dalrrd_emc_dcpr/templates/email_notifications/dataset_maintenance_request_body.txt
+++ b/ckanext/dalrrd_emc_dcpr/templates/email_notifications/dataset_maintenance_request_body.txt
@@ -1,0 +1,11 @@
+You are receiving this email because you are an administrator of the {{ organization.name }} organization in the SASDI Electronic Metadata Catalogue
+
+User {{ user_obj.name }} is requesting that dataset {{ dataset.title }} be unpublished so that it may be modified.
+
+If you wish to comply with this request, proceed to:
+
+- Visit the dataset detail page at {{ site_url }}{{ h.url_for("dataset.read", id=dataset.name) }}
+- Click the "Manage" button
+- Set the dataset's "Visibility" property to "Private"
+
+This shall allow users in the {{ organization.name }} organization which have the `editor` role to be able to modify the dataset.

--- a/ckanext/dalrrd_emc_dcpr/templates/email_notifications/dataset_maintenance_request_subject.txt
+++ b/ckanext/dalrrd_emc_dcpr/templates/email_notifications/dataset_maintenance_request_subject.txt
@@ -1,0 +1,1 @@
+{{ site_title }} Dataset maintenance request

--- a/ckanext/dalrrd_emc_dcpr/templates/email_notifications/dataset_publication_request_body.txt
+++ b/ckanext/dalrrd_emc_dcpr/templates/email_notifications/dataset_publication_request_body.txt
@@ -1,0 +1,11 @@
+You are receiving this email because you are an administrator of the {{ organization.name }} organization in the SASDI Electronic Metadata Catalogue
+
+User {{ user_obj.name }} is requesting that dataset {{ dataset.title }} be published.
+
+If you wish to comply with this request, proceed to:
+
+- Visit the dataset detail page at {{ site_url }}{{ h.url_for("dataset.read", id=dataset.name) }}
+- Click the "Manage" button
+- Set the dataset's "Visibility" property to "Public"
+
+This shall make the dataset available to everyone, including non-authenticated users.

--- a/ckanext/dalrrd_emc_dcpr/templates/email_notifications/dataset_publication_request_subject.txt
+++ b/ckanext/dalrrd_emc_dcpr/templates/email_notifications/dataset_publication_request_subject.txt
@@ -1,0 +1,1 @@
+{{ site_title }} Dataset publication request

--- a/ckanext/dalrrd_emc_dcpr/templates/package/read_base.html
+++ b/ckanext/dalrrd_emc_dcpr/templates/package/read_base.html
@@ -15,6 +15,6 @@
      #}
     {% set user_is_editor = h.emc_user_is_org_member(pkg.owner_org, g.userobj, role="editor") %}
     {% if not pkg.private and user_is_editor and not h.check_access("package_update", {"id": pkg.id}) %}
-        {% link_for _('Request edit'), named_route="emc.request_package_maintenance", id=pkg.name, class_='btn btn-default', icon='wrench' %}
+        {% link_for _('Request edit'), named_route="emc.request_dataset_maintenance", dataset_id=pkg.id, class_='btn btn-default', icon='wrench' %}
     {% endif %}
 {% endblock %}

--- a/ckanext/dalrrd_emc_dcpr/templates/package/read_base.html
+++ b/ckanext/dalrrd_emc_dcpr/templates/package/read_base.html
@@ -14,7 +14,23 @@
 
      #}
     {% set user_is_editor = h.emc_user_is_org_member(pkg.owner_org, g.userobj, role="editor") %}
-    {% if not pkg.private and user_is_editor and not h.check_access("package_update", {"id": pkg.id}) %}
-        {% link_for _('Request edit'), named_route="emc.request_dataset_maintenance", dataset_id=pkg.id, class_='btn btn-default', icon='wrench' %}
+
+
+    {% if user_is_editor %}
+        {% if pkg.private %}
+            {% link_for _('Request publication'),
+                named_route="emc.request_dataset_management",
+                dataset_id=pkg.id,
+                management_command="publication",
+                class_='btn btn-default',
+                icon='graduation-cap' %}
+        {% elif not pkg.private and not h.check_access("package_update", {"id": pkg.id}) %}
+            {% link_for _('Request edit'),
+                named_route="emc.request_dataset_management",
+                dataset_id=pkg.id,
+                management_command="maintenance",
+                class_='btn btn-default',
+                icon='pencil' %}
+        {% endif %}
     {% endif %}
 {% endblock %}

--- a/ckanext/dalrrd_emc_dcpr/templates/snippets/activities/requested_dataset_maintenance.html
+++ b/ckanext/dalrrd_emc_dcpr/templates/snippets/activities/requested_dataset_maintenance.html
@@ -1,0 +1,25 @@
+{% set dataset_type = activity.data.package.type or 'dataset' %}
+
+<li class="item {{ activity.activity_type|replace(' ', '-')|lower }}">
+    <i class="fa icon fa-sitemap"></i>
+    <p>
+        {{ _('{actor} requested maintenance of dataset {dataset}').format(
+      actor=ah.actor(activity),
+      dataset=ah.dataset(activity)
+    )|safe }}
+        <br />
+        <span class="date" title="{{ h.render_datetime(activity.timestamp, with_hours=True) }}">
+      {{ h.time_ago_from_timestamp(activity.timestamp) }}
+            {% if can_show_activity_detail %}
+                &nbsp;|&nbsp;
+                <a href="{{ h.url_for(dataset_type ~ '.read', id=activity.object_id, activity_id=activity.id) }}">
+          {{ _('View this version') }}
+        </a>
+                &nbsp;|&nbsp;
+                <a href="{{ h.url_for(dataset_type ~ '.changes', id=activity.id) }}">
+          {{ _('Changes') }}
+        </a>
+            {% endif %}
+    </span>
+    </p>
+</li>

--- a/docker/ckan-dev-settings.ini
+++ b/docker/ckan-dev-settings.ini
@@ -177,7 +177,7 @@ ckan.harvest.mq.redis_db = 0
 
 ## Front-End Settings
 
-ckan.site_title = CKAN
+ckan.site_title = SASDI EMC/DCPR
 ckan.site_logo = /images/Logo.png
 ckan.site_description =
 ckan.favicon = /images/favicon.ico

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -42,6 +42,15 @@ services:
       - target: 5000
         published: *ckan-web-published-port
 
+  ckan-background-worker:
+    <<: *partial-ckan-volumes
+    environment:
+      CKAN_SMTP_SERVER: ${CKAN_SMTP_SERVER}
+      CKAN_SMTP_STARTTLS: ${CKAN_SMTP_STARTTLS}
+      CKAN_SMTP_USER: ${CKAN_SMTP_USER}
+      CKAN_SMTP_PASSWORD: ${CKAN_SMTP_PASSWORD}
+      CKAN_SMTP_MAIL_FROM: ${CKAN_SMTP_MAIL_FROM}
+
   ckan-harvesting-fetcher:
     <<: *partial-ckan-volumes
 

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -34,6 +34,14 @@ x-partial-ckan-volumes: &partial-ckan-volumes
       target: /home/appuser/who.ini
     - ckan-storage:/home/appuser/data
 
+x-email-environment-values: &partial-email-environment-values
+  CKAN_SMTP_SERVER: ${CKAN_SMTP_SERVER}
+  CKAN_SMTP_STARTTLS: ${CKAN_SMTP_STARTTLS}
+  CKAN_SMTP_USER: ${CKAN_SMTP_USER}
+  CKAN_SMTP_PASSWORD: ${CKAN_SMTP_PASSWORD}
+  CKAN_SMTP_MAIL_FROM: ${CKAN_SMTP_MAIL_FROM}
+
+
 services:
 
   ckan-web:
@@ -45,11 +53,7 @@ services:
   ckan-background-worker:
     <<: *partial-ckan-volumes
     environment:
-      CKAN_SMTP_SERVER: ${CKAN_SMTP_SERVER}
-      CKAN_SMTP_STARTTLS: ${CKAN_SMTP_STARTTLS}
-      CKAN_SMTP_USER: ${CKAN_SMTP_USER}
-      CKAN_SMTP_PASSWORD: ${CKAN_SMTP_PASSWORD}
-      CKAN_SMTP_MAIL_FROM: ${CKAN_SMTP_MAIL_FROM}
+      *partial-email-environment-values
 
   ckan-harvesting-fetcher:
     <<: *partial-ckan-volumes
@@ -63,11 +67,7 @@ services:
   ckan-mail-sender:
     <<: *partial-ckan-volumes
     environment:
-      CKAN_SMTP_SERVER: ${CKAN_SMTP_SERVER}
-      CKAN_SMTP_STARTTLS: ${CKAN_SMTP_STARTTLS}
-      CKAN_SMTP_USER: ${CKAN_SMTP_USER}
-      CKAN_SMTP_PASSWORD: ${CKAN_SMTP_PASSWORD}
-      CKAN_SMTP_MAIL_FROM: ${CKAN_SMTP_MAIL_FROM}
+      *partial-email-environment-values
 
   ckan-db:
     environment:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,6 +7,10 @@ services:
   ckan-web:
     image: kartoza/ckanext-dalrrd-emc-dcpr:${CKAN_IMAGE_TAG}
 
+  ckan-background-worker:
+    image: kartoza/ckanext-dalrrd-emc-dcpr:${CKAN_IMAGE_TAG}
+    command: ["launch-ckan-cli", "jobs", "worker"]
+
   ckan-harvesting-gatherer:
     image: kartoza/ckanext-dalrrd-emc-dcpr:${CKAN_IMAGE_TAG}
     command: ["launch-ckan-cli", "harvester", "gather-consumer"]


### PR DESCRIPTION
This PR implements a way to let dataset editors request that dataset publishers:

- publish a dataset
- unpublish a dataset (so that it becomes editable)

it adds a couple of new buttons to the UI (backed by corresponding CKAN actions, so they are also available via API) that are accessible to dataset editors. They look like this:

- Dataset publication request

  ![image](https://user-images.githubusercontent.com/732010/158650955-9904a935-a62d-4d00-8803-fdfb1319974e.png)

- Dataset edition request

  ![image](https://user-images.githubusercontent.com/732010/158651047-a3c33a6e-6619-4362-a5dc-76122ac61eed.png)

When a user presses one of these buttons:

- There is a new activity created and shown on the user's dashboard with the specified action

  ![image](https://user-images.githubusercontent.com/732010/158651277-eb90866b-7ea4-431d-8f13-694f006328fe.png)

- The owner organization's publishers are notified via e-mail using a background job that the user is requesting that they take action

- The user is made to follow the dataset and its profile setting to receive e-mail notifications is also enabled - this means that when one of the dataset publishers acts upon the pending request, the user receives an e-mail notification too


fixes #107
fixes #159