### PR TITLE
Extend user profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,16 @@ Additionally, in order for notifications to work, there is some configuration:
   it finds interesting enough in order to be notified of changes via email
 
 
+#### Use a shell for interacting with CKAN
+
+There is a CLI command that allows opening a Python shell already configured with the
+CKAN environment. This is analogous to django's `manage.py shell` command. Start it up with:
+
+```
+ckan dalrrd-emc-dcpr shell
+```
+
+
 
 ## Development
 

--- a/ckanext/dalrrd_emc_dcpr/cli/commands.py
+++ b/ckanext/dalrrd_emc_dcpr/cli/commands.py
@@ -1,13 +1,13 @@
 """CKAN CLI commands for the dalrrd-emc-dcpr extension"""
 
-import contextlib
 import datetime as dt
 import enum
-import io
 import inspect
 import json
 import logging
 import os
+import sys
+import traceback
 import typing
 from concurrent import futures
 from pathlib import Path
@@ -23,7 +23,6 @@ from ckan.plugins import toolkit
 from ckan import model
 from ckan.lib.navl import dictization_functions
 
-# from ckan.lib.email_notifications import get_and_send_notifications_for_all_users
 from ckanext.dalrrd_emc_dcpr.model.dcpr_request import (
     DCPRRequest,
     DCPRGeospatialRequest,
@@ -106,6 +105,51 @@ def delete_data():
 @dalrrd_emc_dcpr.group()
 def extra_commands():
     """Extra commands that are less relevant"""
+
+
+@dalrrd_emc_dcpr.command()
+def shell():
+    """
+    Launch a shell with CKAN already imported and ready to explore
+
+    The implementation of this command is mostly inspired and adapted from django's
+    `shell` command
+
+    """
+
+    try:
+        from IPython import start_ipython
+
+        start_ipython(argv=[])
+    except ImportError:
+        import code
+
+        # Set up a dictionary to serve as the environment for the shell.
+        imported_objects = {}
+
+        # By default, this will set up readline to do tab completion and to read and
+        # write history to the .python_history file, but this can be overridden by
+        # $PYTHONSTARTUP or ~/.pythonrc.py.
+        try:
+            sys.__interactivehook__()
+        except Exception:
+            # Match the behavior of the cpython shell where an error in
+            # sys.__interactivehook__ prints a warning and the exception and continues.
+            print("Failed calling sys.__interactivehook__")
+            traceback.print_exc()
+
+        # Set up tab completion for objects imported by $PYTHONSTARTUP or
+        # ~/.pythonrc.py.
+        try:
+            import readline
+            import rlcompleter
+
+            readline.set_completer(rlcompleter.Completer(imported_objects).complete)
+        except ImportError:
+            pass
+
+        # Start the interactive interpreter.
+        code.interact(local=imported_objects)
 
 
 @bootstrap.command()

--- a/ckanext/dalrrd_emc_dcpr/migration/dalrrd_emc_dcpr/versions/a794534e0216_add_user_extra_fields_table.py
+++ b/ckanext/dalrrd_emc_dcpr/migration/dalrrd_emc_dcpr/versions/a794534e0216_add_user_extra_fields_table.py
@@ -1,0 +1,46 @@
+"""add-user-extra-fields-table
+
+Revision ID: a794534e0216
+Revises: 6831fb82e888
+Create Date: 2022-03-18 18:30:52.915020
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+from sqlalchemy import types, ForeignKey
+from ckan.model import core, domain_object, meta, types as ckan_types
+
+
+# revision identifiers, used by Alembic.
+revision = "a794534e0216"
+down_revision = "6831fb82e888"
+branch_labels = None
+depends_on = None
+
+_TABLE_NAME = "user_extra_fields"
+
+
+def upgrade():
+    op.create_table(
+        _TABLE_NAME,
+        meta.metadata,
+        sa.Column(
+            "id",
+            types.UnicodeText,
+            primary_key=True,
+            default=ckan_types.make_uuid,
+        ),
+        sa.Column(
+            "user_id",
+            types.UnicodeText,
+            ForeignKey("user.id"),
+            nullable=False,
+        ),
+        sa.Column("affiliation", types.UnicodeText),
+        sa.Column("professional_occupation", types.UnicodeText),
+    )
+
+
+def downgrade():
+    op.drop_table(_TABLE_NAME)

--- a/ckanext/dalrrd_emc_dcpr/model/user_extra_fields.py
+++ b/ckanext/dalrrd_emc_dcpr/model/user_extra_fields.py
@@ -1,0 +1,47 @@
+"""Additional fields for the user model for storing affiliation details"""
+
+import logging
+
+import sqlalchemy
+from ckan import model
+from ckan.model import types as types_
+from sqlalchemy import orm
+
+logger = logging.getLogger(__name__)
+
+user_extra_fields_table = sqlalchemy.Table(
+    "user_extra_fields",
+    sqlalchemy.Column(
+        "id", sqlalchemy.types.UnicodeText, primary_key=True, default=types_.make_uuid
+    ),
+    sqlalchemy.Column(
+        "user_id",
+        sqlalchemy.types.UnicodeText,
+        sqlalchemy.ForeignKey("user.id"),
+    ),
+    sqlalchemy.Column(
+        "affiliation",
+        sqlalchemy.types.UnicodeText,
+    ),
+    sqlalchemy.Column(
+        "professional_occupation",
+        sqlalchemy.types.UnicodeText,
+    ),
+)
+
+
+class UserExtraFields(model.core.StatefulObjectMixin, model.domain_object.DomainObject):
+    pass
+
+
+model.meta.mapper(
+    UserExtraFields,
+    user_extra_fields_table,
+    properties={
+        "user": orm.relationship(
+            model.User,
+            uselist=False,
+            backref=orm.backref("_extra_fields", cascade="all, delete, delete-orphan"),
+        ),
+    },
+)

--- a/ckanext/dalrrd_emc_dcpr/model/user_extra_fields.py
+++ b/ckanext/dalrrd_emc_dcpr/model/user_extra_fields.py
@@ -4,13 +4,17 @@ import logging
 
 import sqlalchemy
 from ckan import model
-from ckan.model import types as types_
+from ckan.model import (
+    meta,
+    types as types_,
+)
 from sqlalchemy import orm
 
 logger = logging.getLogger(__name__)
 
 user_extra_fields_table = sqlalchemy.Table(
     "user_extra_fields",
+    meta.metadata,
     sqlalchemy.Column(
         "id", sqlalchemy.types.UnicodeText, primary_key=True, default=types_.make_uuid
     ),
@@ -40,8 +44,11 @@ model.meta.mapper(
     properties={
         "user": orm.relationship(
             model.User,
-            uselist=False,
-            backref=orm.backref("_extra_fields", cascade="all, delete, delete-orphan"),
+            backref=orm.backref(
+                "extra_fields",
+                uselist=False,
+                cascade="all, delete, delete-orphan",
+            ),
         ),
     },
 )

--- a/ckanext/dalrrd_emc_dcpr/plugin.py
+++ b/ckanext/dalrrd_emc_dcpr/plugin.py
@@ -172,6 +172,9 @@ class DalrrdEmcDcprPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
             "emc_request_dataset_maintenance": emc_actions.request_dataset_maintenance,
             "emc_request_dataset_publication": emc_actions.request_dataset_publication,
             "emc_user_patch": ckan_actions.user_patch,
+            "user_update": ckan_actions.user_update,
+            "user_create": ckan_actions.user_create,
+            "user_show": ckan_actions.user_show,
         }
 
     def get_validators(self) -> typing.Dict[str, typing.Callable]:

--- a/ckanext/dalrrd_emc_dcpr/templates/user/edit_user_form.html
+++ b/ckanext/dalrrd_emc_dcpr/templates/user/edit_user_form.html
@@ -1,0 +1,66 @@
+{% import 'macros/form.html' as form %}
+
+<form id="user-edit-form" class="dataset-form" method="post" action="{{ action }}" enctype="multipart/form-data">
+  {{ form.errors(error_summary) }}
+
+  <fieldset>
+    <legend>{{ _('Change details') }}</legend>
+    {{ form.input('name', label=_('Username'), id='field-username', value=data.name, error=errors.name, classes=['control-medium'], attrs={'readonly': '', 'class': 'form-control'}) }}
+
+    {{ form.input('fullname', label=_('Full name'), id='field-fullname', value=data.fullname, error=errors.fullname, placeholder=_('eg. Joe Bloggs'), classes=['control-medium']) }}
+
+    {{ form.input('email', label=_('Email'), id='field-email', type='email', value=data.email, error=errors.email, placeholder=_('eg. joe@example.com'), classes=['control-medium'], is_required=true) }}
+
+    {{ form.markdown('about', label=_('About'), id='field-about', value=data.about, error=errors.about, placeholder=_('A little information about yourself')) }}
+
+    {% if show_email_notifications %}
+      {% call form.checkbox('activity_streams_email_notifications', label=_('Subscribe to notification emails'), id='field-activity-streams-email-notifications', value=True, checked=g.userobj.activity_streams_email_notifications) %}
+      {% set helper_text = _("You will receive notification emails from {site_title}, e.g. when you have new activities on your dashboard."|string) %}
+      {{ form.info(helper_text.format(site_title=g.site_title), classes=['info-help-tight']) }}
+      {% endcall %}
+    {% endif %}
+
+    {% set is_upload = data.image_url and not data.image_url.startswith('http') %}
+    {% set is_url = data.image_url and data.image_url.startswith('http') %}
+
+    {{ form.image_upload(data, errors, is_upload_enabled=h.uploads_enabled(), is_url=is_url, is_upload=is_upload, upload_label=_('Profile picture'), url_label=_('Profile picture URL') ) }}
+
+  </fieldset>
+    <fieldset>
+        <legend>{{ _('Extra details') }}</legend>
+        {{ form.input('extra_fields_affiliation', label=_('Affiliation'), id='field-extra-details-affiliation', value=data.extra_fields.affiliation, error=errors.affiliation, classes=['control-medium']) }}
+
+        {{ form.input('extra_fields_professional_occupation', label=_('Professional Occupation'), id='field-extra-details-professional-occupation', value=data.extra_fields.professional_occupation, error=errors.professional_occupation, placeholder=_('eg. Department Head'), classes=['control-medium']) }}
+    </fieldset>
+
+  <fieldset>
+    <legend>{{ _('Change password') }}</legend>
+    {{ form.input('old_password',
+                  type='password',
+                  label=_('Sysadmin Password') if is_sysadmin else _('Old Password'),
+                  id='field-password-old',
+                  value=data.oldpassword,
+                  error=errors.oldpassword,
+                  classes=['control-medium'],
+                  attrs={'autocomplete': 'off', 'class': 'form-control'}
+                  ) }}
+
+    {{ form.input('password1', type='password', label=_('Password'), id='field-password', value=data.password1, error=errors.password1, classes=['control-medium'], attrs={'autocomplete': 'off', 'class': 'form-control'} ) }}
+
+    {{ form.input('password2', type='password', label=_('Confirm Password'), id='field-password-confirm', value=data.password2, error=errors.password2, classes=['control-medium'], attrs={'autocomplete': 'off', 'class': 'form-control'}) }}
+
+  <div class="form-actions">
+    {% block delete_button %}
+      {% if h.check_access('user_delete', {'id': data.id})  %}
+        <a class="btn btn-danger pull-left" href="{% url_for 'user_delete', id=data.id %}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this User?') }}">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>
+      {% endif %}
+    {% endblock %}
+    {% block generate_button %}
+      {% if h.check_access('user_generate_apikey', {'id': data.id})  %}
+        <a class="btn btn-warning" href="{% url_for 'user.generate_apikey', id=data.id %}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to regenerate the API key?') }}">{% block generate_button_text %}{{ _('Regenerate API Key') }}{% endblock %}</a>
+      {% endif %}
+    {% endblock %}
+    {{ form.required_message() }}
+    <button class="btn btn-primary" type="submit" name="save">{{ _('Update Profile') }}</button>
+  </div>
+</form>


### PR DESCRIPTION
This PR adds a couple of fields to a user's profile:

- `affiliation`
- `professional occupation`

These are meant for enabling the user to provide a bit more detail about him/herself.

Implementation is based around the definition of a new `user_extra_fields` DB table. This new table has a 1:1 relationship with the stock `models.User` user model. The PR also makes extensive use of the `toolkit.chained_action` decorator, as it overrides the stock CKAN user actions to also populate these extra fields.

This PR also introduces a new CLI command that exposes an interactive shell. This was based on the `django shell` command. The shell presents an automatically configured environment,which is ideal for playing with the CKAN API. Use it like this:

```python
ckan dalrrd-emc-dcpr shell
```

fixes #140 