### PR TITLE
Sysadmin users can now properly interact with dcpr section

### DIFF
--- a/ckanext/dalrrd_emc_dcpr/blueprints/dcpr.py
+++ b/ckanext/dalrrd_emc_dcpr/blueprints/dcpr.py
@@ -43,6 +43,11 @@ def get_awaiting_csi_moderation_dcpr_requests():
     return _get_dcpr_request_list("dcpr_request_list_awaiting_csi_moderation")
 
 
+@dcpr_blueprint.route("/under-preparation-dcpr-requests")
+def get_under_preparation_dcpr_requests():
+    return _get_dcpr_request_list("dcpr_request_list_under_preparation")
+
+
 def _get_dcpr_request_list(ckan_action: str, should_show_create_action: bool = False):
     try:
         dcpr_requests = toolkit.get_action(ckan_action)(
@@ -77,10 +82,23 @@ class DcprRequestCreateView(MethodView):
         )
         if "organization_id" not in request.args:
             # if we don't already have an org id, need to let user choose from those orgs where she is a member
-            current_memberships = toolkit.h["emc_org_memberships"](toolkit.g.userobj.id)
-            relevant_orgs = [
-                {"value": org.id, "text": org.name} for org, _ in current_memberships
-            ]
+            if toolkit.g.userobj.sysadmin:
+                current_memberships = (
+                    ckan.model.Session.query(ckan.model.Group)
+                    .filter(ckan.model.Group.is_organization)
+                    .all()
+                )
+                relevant_orgs = [
+                    {"value": org.id, "text": org.name} for org in current_memberships
+                ]
+            else:
+                current_memberships = toolkit.h["emc_org_memberships"](
+                    toolkit.g.userobj.id
+                )
+                relevant_orgs = [
+                    {"value": org.id, "text": org.name}
+                    for org, _ in current_memberships
+                ]
         else:
             # if we have an org id in request.args then there is no need to show the orgs select
             relevant_orgs = None

--- a/ckanext/dalrrd_emc_dcpr/logic/action/dcpr/get.py
+++ b/ckanext/dalrrd_emc_dcpr/logic/action/dcpr/get.py
@@ -54,11 +54,18 @@ def my_dcpr_request_list(
 
 
 @toolkit.side_effect_free
-def dcpr_request_list_private(
+def dcpr_request_list_under_preparation(
     context: typing.Dict, data_dict: typing.Dict
 ) -> typing.List[typing.Dict]:
-    """Return a list of private DCPR requests"""
-    toolkit.check_access("dcpr_request_list_private_auth", context, data_dict or {})
+    """Return a list of DCPR requests that are still being prepared.
+
+    This function returns all DCPR requests that are being prepared by all users.
+
+    """
+
+    toolkit.check_access(
+        "dcpr_request_list_under_preparation_auth", context, data_dict or {}
+    )
     return _get_dcpr_request_list(
         context,
         data_dict,

--- a/ckanext/dalrrd_emc_dcpr/logic/action/dcpr/update.py
+++ b/ckanext/dalrrd_emc_dcpr/logic/action/dcpr/update.py
@@ -119,6 +119,18 @@ def dcpr_request_submit(context, data_dict):
     )
     if request_obj is not None:
         _update_dcpr_request_status(request_obj)
+        # the sysadmin is authorized to submit a DCPR request - however we want
+        # to track that this action has been carried out by the sysadmin and not
+        # by the DCPR request's original owner. If the sysadmin submits a DCPR request
+        # then it effectively becomes the responsible for the DCPR request, so we make
+        # it the owner of the request.
+        if context["auth_user_obj"].sysadmin:
+            request_obj.owner_user = context["auth_user_obj"].id
+            logger.info(
+                f"sysadmin {context['auth_user_obj'].id} has now been made the owner "
+                f"of DCPR request {request_obj.csi_reference_id}"
+            )
+
         model.Session.commit()
         activity = create_dcpr_management_activity(
             request_obj,
@@ -167,6 +179,16 @@ def dcpr_request_nsif_moderate(
             _update_dcpr_request_status(
                 request_obj, transition_action=moderation_action
             )
+            # the sysadmin is authorized to moderate a DCPR request - however we want
+            # to track that this action has been carried out by the sysadmin and not
+            # by the DCPR request's original NSIF reviewer. As such we change the NSIF
+            # reviewer of the DCPR request if the current moderator is a sysadmin
+            if context["auth_user_obj"].sysadmin:
+                request_obj.nsif_reviewer = context["auth_user_obj"].id
+                logger.info(
+                    f"sysadmin {context['auth_user_obj'].id} has now been made the "
+                    f"NSIF reviewer for DCPR request {request_obj.csi_reference_id}"
+                )
             context["model"].Session.commit()
             activity_type = {
                 DcprRequestModerationAction.APPROVE: DcprManagementActivityType.ACCEPT_DCPR_REQUEST_NSIF,
@@ -212,6 +234,16 @@ def dcpr_request_csi_moderate(
             _update_dcpr_request_status(
                 request_obj, transition_action=moderation_action
             )
+            # The sysadmin is authorized to moderate a DCPR request - however we want
+            # to track that this action has been carried out by the sysadmin and not
+            # by the DCPR request's original CSI moderator. As such we change the CSI
+            # moderator of the DCPR request if the current moderator is a sysadmin
+            if context["auth_user_obj"].sysadmin:
+                request_obj.csi_moderator = context["auth_user_obj"].id
+                logger.info(
+                    f"sysadmin {context['auth_user_obj'].id} has now been made the "
+                    f"CSI moderator for DCPR request {request_obj.csi_reference_id}"
+                )
             context["model"].Session.commit()
             activity_type = {
                 DcprRequestModerationAction.APPROVE: DcprManagementActivityType.ACCEPT_DCPR_REQUEST_CSI,

--- a/ckanext/dalrrd_emc_dcpr/logic/action/dcpr/update.py
+++ b/ckanext/dalrrd_emc_dcpr/logic/action/dcpr/update.py
@@ -112,12 +112,12 @@ def dcpr_request_submit(context, data_dict):
         raise toolkit.ValidationError(errors)
 
     toolkit.check_access("dcpr_request_submit_auth", context, validated_data)
-    validated_data["submission_date"] = dt.datetime.now(dt.timezone.utc)
     model = context["model"]
     request_obj = model.Session.query(dcpr_request.DCPRRequest).get(
         validated_data["csi_reference_id"]
     )
     if request_obj is not None:
+        request_obj.submission_date = dt.datetime.now(dt.timezone.utc)
         _update_dcpr_request_status(request_obj)
         # the sysadmin is authorized to submit a DCPR request - however we want
         # to track that this action has been carried out by the sysadmin and not

--- a/ckanext/dalrrd_emc_dcpr/logic/auth/dcpr.py
+++ b/ckanext/dalrrd_emc_dcpr/logic/auth/dcpr.py
@@ -244,7 +244,7 @@ def dcpr_request_update_by_csi_auth(
     if request_obj is not None:
         if request_obj.status == DCPRRequestStatus.UNDER_CSI_REVIEW.value:
             is_moderator = request_obj.csi_moderator == context["auth_user_obj"].id
-            if is_moderator or request_obj["auth_user_obj"].sysadmin:
+            if is_moderator or context["auth_user_obj"].sysadmin:
                 result["success"] = True
             else:
                 result["msg"] = toolkit._(

--- a/ckanext/dalrrd_emc_dcpr/logic/auth/dcpr.py
+++ b/ckanext/dalrrd_emc_dcpr/logic/auth/dcpr.py
@@ -34,26 +34,46 @@ def dcpr_request_list_public_auth(
     return {"success": True}
 
 
+def dcpr_request_list_under_preparation_auth(
+    context: typing.Dict, data_dict: typing.Optional[typing.Dict] = None
+) -> typing.Dict:
+    """Authorize listing DCPR requests that are still under preparation
+
+    This is a privileged operation that is only available to the CKAN sysadmins.
+
+    """
+
+    return {"success": context["auth_user_obj"].sysadmin}
+
+
 def dcpr_request_list_pending_csi_auth(
     context: typing.Dict, data_dict: typing.Optional[typing.Dict] = None
 ):
     """Authorize listing DCPR requests which are under evaluation by CSI"""
-    return {
-        "success": toolkit.h["emc_user_is_org_member"](
+    result = {"success": False}
+    if context["auth_user_obj"].sysadmin:
+        result["success"] = True
+    else:
+        result["success"] = toolkit.h["emc_user_is_org_member"](
             CSI_ORG_NAME, context["auth_user_obj"]
         )
-    }
+    return result
 
 
 def dcpr_request_list_pending_nsif_auth(
     context: typing.Dict, data_dict: typing.Optional[typing.Dict] = None
 ):
     """Authorize listing DCPR requests which are under evaluation by NSIF"""
-    return {
-        "success": toolkit.h["emc_user_is_org_member"](
-            NSIF_ORG_NAME, context["auth_user_obj"]
-        )
-    }
+    result = {"success": False}
+    if context["auth_user_obj"].sysadmin:
+        result["success"] = True
+    else:
+        result = {
+            "success": toolkit.h["emc_user_is_org_member"](
+                NSIF_ORG_NAME, context["auth_user_obj"]
+            )
+        }
+    return result
 
 
 def dcpr_report_create_auth(
@@ -74,7 +94,7 @@ def dcpr_request_create_auth(
     """Authorize DCPR request creation.
 
     Creation of DCPR requests is reserved for logged in users that have been granted
-    membership of an organization.
+    membership of an organization or for sysadmin users.
 
     NOTE: The implementation does not need to check if the user is logged in because
     CKAN already does that for us, as per:
@@ -84,8 +104,12 @@ def dcpr_request_create_auth(
     """
 
     db_user = context["auth_user_obj"]
-    member_of_orgs = len(db_user.get_groups()) > 0
-    result = {"success": member_of_orgs}
+    result = {"success": False}
+    if db_user.sysadmin:
+        result["success"] = True
+    else:
+        member_of_orgs = len(db_user.get_groups()) > 0
+        result = {"success": member_of_orgs}
     return result
 
 
@@ -154,6 +178,8 @@ def dcpr_request_update_by_owner_auth(
         if request_obj.status in owner_updatable_statuses:
             if context["auth_user_obj"].id == request_obj.owner_user:
                 result["success"] = True
+            elif context["auth_user_obj"].sysadmin:
+                result["success"] = True
             else:
                 result["msg"] = toolkit._(
                     "Current user is not authorized to update this DCPR request"
@@ -183,7 +209,7 @@ def dcpr_request_update_by_nsif_auth(
     if request_obj is not None:
         if request_obj.status == DCPRRequestStatus.UNDER_NSIF_REVIEW.value:
             is_reviewer = request_obj.nsif_reviewer == context["auth_user_obj"].id
-            if is_reviewer:
+            if is_reviewer or context["auth_user_obj"].sysadmin:
                 result["success"] = True
             else:
                 result["msg"] = toolkit._(
@@ -218,7 +244,7 @@ def dcpr_request_update_by_csi_auth(
     if request_obj is not None:
         if request_obj.status == DCPRRequestStatus.UNDER_CSI_REVIEW.value:
             is_moderator = request_obj.csi_moderator == context["auth_user_obj"].id
-            if is_moderator:
+            if is_moderator or request_obj["auth_user_obj"].sysadmin:
                 result["success"] = True
             else:
                 result["msg"] = toolkit._(
@@ -248,7 +274,9 @@ def dcpr_request_nsif_moderate_auth(
     result = {"success": False}
     if request_obj is not None:
         if request_obj.status == DCPRRequestStatus.UNDER_NSIF_REVIEW.value:
-            if context["auth_user_obj"].id == request_obj.nsif_reviewer:
+            if context["auth_user_obj"].sysadmin:
+                result["success"] = True
+            elif context["auth_user_obj"].id == request_obj.nsif_reviewer:
                 result["success"] = True
             else:
                 result["msg"] = toolkit._(
@@ -272,7 +300,9 @@ def dcpr_request_csi_moderate_auth(
     result = {"success": False}
     if request_obj is not None:
         if request_obj.status == DCPRRequestStatus.UNDER_CSI_REVIEW.value:
-            if context["auth_user_obj"].id == request_obj.csi_moderator:
+            if context["auth_user_obj"].sysadmin:
+                result["success"] = True
+            elif context["auth_user_obj"].id == request_obj.csi_moderator:
                 result["success"] = True
             else:
                 result["msg"] = toolkit._(
@@ -305,7 +335,7 @@ def dcpr_request_delete_auth(
         request_in_preparation = (
             request_obj.status == DCPRRequestStatus.UNDER_PREPARATION.value
         )
-        if is_owner and request_in_preparation:
+        if (is_owner or context["auth_user_obj"].sysadmin) and request_in_preparation:
             result["success"] = True
     else:
         result["msg"] = toolkit._("Request not found")
@@ -320,21 +350,24 @@ def dcpr_request_claim_nsif_reviewer_auth(
     request_obj = dcpr_request.DCPRRequest.get(request_id)
     result = {"success": False}
     if request_obj is not None:
-        is_nsif_member = toolkit.h["emc_user_is_org_member"](
-            NSIF_ORG_NAME, context["auth_user_obj"]
-        )
-        if is_nsif_member:
-            if request_obj.status == DCPRRequestStatus.AWAITING_NSIF_REVIEW.value:
-                result["success"] = True
+        if context["auth_user_obj"].sysadmin:
+            result["success"] = True
+        else:
+            is_nsif_member = toolkit.h["emc_user_is_org_member"](
+                NSIF_ORG_NAME, context["auth_user_obj"]
+            )
+            if is_nsif_member:
+                if request_obj.status == DCPRRequestStatus.AWAITING_NSIF_REVIEW.value:
+                    result["success"] = True
+                else:
+                    result["msg"] = toolkit._(
+                        "DCPR request cannot currently be claimed for NSIF review"
+                    )
             else:
                 result["msg"] = toolkit._(
-                    "DCPR request cannot currently be claimed for NSIF review"
+                    "Current user is not authorized to claim the role of NSIF reviewer "
+                    "for this DCPR request"
                 )
-        else:
-            result["msg"] = toolkit._(
-                "Current user is not authorized to claim the role of NSIF reviewer "
-                "for this DCPR request"
-            )
     else:
         result["msg"] = toolkit._("Request not found")
     return result
@@ -348,21 +381,24 @@ def dcpr_request_claim_csi_moderator_auth(
     request_obj = dcpr_request.DCPRRequest.get(request_id)
     result = {"success": False}
     if request_obj is not None:
-        is_csi_member = toolkit.h["emc_user_is_org_member"](
-            CSI_ORG_NAME, context["auth_user_obj"]
-        )
-        if is_csi_member:
-            if request_obj.status == DCPRRequestStatus.AWAITING_CSI_REVIEW.value:
-                result["success"] = True
+        if context["auth_user_obj"].sysadmin:
+            result["success"] = True
+        else:
+            is_csi_member = toolkit.h["emc_user_is_org_member"](
+                CSI_ORG_NAME, context["auth_user_obj"]
+            )
+            if is_csi_member:
+                if request_obj.status == DCPRRequestStatus.AWAITING_CSI_REVIEW.value:
+                    result["success"] = True
+                else:
+                    result["msg"] = toolkit._(
+                        "DCPR request cannot currently be claimed for CSI review"
+                    )
             else:
                 result["msg"] = toolkit._(
-                    "DCPR request cannot currently be claimed for CSI review"
+                    "Current user is not authorized to claim the role of CSI moderator "
+                    "for this DCPR request"
                 )
-        else:
-            result["msg"] = toolkit._(
-                "Current user is not authorized to claim the role of CSI moderator "
-                "for this DCPR request"
-            )
     else:
         result["msg"] = toolkit._("Request not found")
     return result

--- a/ckanext/dalrrd_emc_dcpr/plugins/emc_dcpr_plugin.py
+++ b/ckanext/dalrrd_emc_dcpr/plugins/emc_dcpr_plugin.py
@@ -225,6 +225,7 @@ class DalrrdEmcDcprPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
             "my_dcpr_request_list_auth": dcpr_auth.my_dcpr_request_list_auth,
             "dcpr_request_list_public_auth": dcpr_auth.dcpr_request_list_public_auth,
             "dcpr_request_list_private_auth": dcpr_auth.dcpr_request_list_private_auth,
+            "dcpr_request_list_under_preparation_auth": dcpr_auth.dcpr_request_list_under_preparation_auth,
             "dcpr_request_list_pending_csi_auth": (
                 dcpr_auth.dcpr_request_list_pending_csi_auth
             ),
@@ -265,9 +266,8 @@ class DalrrdEmcDcprPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
                 dcpr_create_actions.dcpr_geospatial_request_create
             ),
             "dcpr_request_list_public": dcpr_get_actions.dcpr_request_list_public,
+            "dcpr_request_list_under_preparation": dcpr_get_actions.dcpr_request_list_under_preparation,
             "my_dcpr_request_list": dcpr_get_actions.my_dcpr_request_list,
-            # TODO: This action does not seem to be needed
-            "dcpr_request_list_private": dcpr_get_actions.dcpr_request_list_private,
             "dcpr_request_list_awaiting_csi_moderation": (
                 dcpr_get_actions.dcpr_request_list_awaiting_csi_moderation
             ),

--- a/ckanext/dalrrd_emc_dcpr/templates/dcpr/list.html
+++ b/ckanext/dalrrd_emc_dcpr/templates/dcpr/list.html
@@ -3,6 +3,7 @@
 {% set able_to_create_request = h.check_access('dcpr_request_create_auth') %}
 {% set is_nsif_member = h.emc_user_is_org_member('nsif', g.userobj) %}
 {% set is_csi_member = h.emc_user_is_org_member('csi', g.userobj) %}
+{% set is_sysadmin = g.userobj.sysadmin %}
 {% set has_multiple_request_types = able_to_create_request or is_nsif_member or is_csi_member %}
 
 {% block subtitle %}{{ _('DCPR Requests') }} - {{ super() }}{% endblock %}
@@ -12,16 +13,19 @@
 {% endblock%}
 
 {% block content_primary_nav %}
-    {% if has_multiple_request_types %}
+    {% if has_multiple_request_types or is_sysadmin %}
         {{ h.build_nav("dcpr.get_public_dcpr_requests", _("Public requests")) }}
         {% if able_to_create_request %}
             {{ h.build_nav("dcpr.get_my_dcpr_requests", _("My requests")) }}
         {% endif %}
-        {%  if is_nsif_member %}
-            {{ h.build_nav("dcpr.get_awaiting_nsif_moderation_dcpr_requests", _("Requests awaiting nsif moderation")) }}
+        {%  if is_nsif_member or is_sysadmin %}
+            {{ h.build_nav("dcpr.get_awaiting_nsif_moderation_dcpr_requests", _("Requests awaiting NSIF moderation")) }}
         {% endif %}
-        {%  if is_csi_member %}
+        {%  if is_csi_member or is_sysadmin %}
             {{ h.build_nav("dcpr.get_awaiting_csi_moderation_dcpr_requests", _("Requests awaiting CSI moderation")) }}
+        {% endif %}
+        {%  if is_sysadmin %}
+            {{ h.build_nav("dcpr.get_under_preparation_dcpr_requests", _("Requests under preparation")) }}
         {% endif %}
     {% endif %}
 {% endblock %}

--- a/ckanext/dalrrd_emc_dcpr/templates/organization/read.html
+++ b/ckanext/dalrrd_emc_dcpr/templates/organization/read.html
@@ -4,7 +4,4 @@
     {% if h.check_access('package_create', {'owner_org': group_dict.id}) %}
         {% snippet 'snippets/add_dataset.html', group=group_dict.id %}
     {% endif %}
-    {% if h.check_access('dcpr_request_create_auth') %}
-        {% link_for _('Create DCPR request'), named_route='dcpr.new_dcpr_request', class_='btn btn-primary', icon='plus-square', organization_id=group_dict.id %}
-    {% endif %}
 {% endblock %}

--- a/docker/compose.py
+++ b/docker/compose.py
@@ -12,6 +12,7 @@ from subprocess import check_output
 logger = logging.getLogger(__name__)
 
 _FALLBACK_GIT_BRANCH = "main"
+_IMAGE_NAME = "kartoza/ckanext-dalrrd-emc-dcpr"
 
 
 def main():
@@ -73,14 +74,13 @@ def _get_image_tag_name() -> typing.Optional[str]:
         .strip("\n")
         .replace("/", "-")
     )
-    image_name = "kartoza/ckanext-dalrrd-emc-dcpr"
     existing_image_tags = check_output(
-        shlex.split(f"docker images {image_name} --format '{{{{.Tag}}}}'"), text=True
+        shlex.split(f"docker images {_IMAGE_NAME} --format '{{{{.Tag}}}}'"), text=True
     ).split("\n")
     if current_git_branch in existing_image_tags:
         logger.info("The current branch already has a built tag, lets use that")
         result = current_git_branch
-    elif "main" in existing_image_tags:
+    elif _FALLBACK_GIT_BRANCH in existing_image_tags:
         logger.info(
             f"The current branch does not have a built tag yet, lets use the "
             f"{_FALLBACK_GIT_BRANCH!r} image tag"


### PR DESCRIPTION
The functionality proposed in this PR enables the CKAN sysadmin users to properly interact with DCPR requests. sysadmins have special privileges and they are able to:

- Create new DCPR requests
- Edit existing DCPR requests, even if they are not the owners of the request
- Submit existing DCPR requests for moderation. In this case, if the sysadmin is submitting a request that was originally created by another user, the sysadmin is nominated the new owner of the DCPR request. This is to ensure that a DCPR request's submitter is properly tracked by the system - on a more practical level, we assume that whoever submits a DCPR request should be responsible for its contents
- Become a NSIF or CSI moderator for a DCPR request
- Resign itself from being a NSIF or CSI moderator for a DCPR request - The sysadmin is not allowed to resign other users of this role though - this can be implemented in the future, if needed
- Moderate a DCPR request on behalf of the NSIF or the CSI - When this happens, the system nominates the sysadmin as the reveiwer, in a similar way as described above


fixes #185