### PR TITLE
Add harvest section

### DIFF
--- a/ckanext/dalrrd_emc_dcpr/templates/header.html
+++ b/ckanext/dalrrd_emc_dcpr/templates/header.html
@@ -35,6 +35,14 @@
                         <i class="fa fa-user" aria-hidden="true"></i>
                         <span class="text">{{ _('Profile') }}</span></a></li>
                     {% set new_activities = h.new_activities() %}
+                    {% if h.emc_org_memberships(c.userobj.id) %}
+                        <li>
+                          <a href="/harvest" title="{{ _('Harvest') }}">
+                            <i class="fa fa-leaf" aria-hidden="true"></i>
+                            <span class="text">{{ _('Harvest') }}</span>
+                          </a>
+                        </li>
+                    {% endif %}
                     <li class="notifications {% if new_activities > 0 %}notifications-important{% endif %}">
                       {% set notifications_tooltip = ngettext('Dashboard (%(num)d new item)', 'Dashboard (%(num)d new items)',
                       new_activities)


### PR DESCRIPTION
fixes #48 

I couldn't find the right view for /harvest link so I didn't use the helper url_for.
![image](https://user-images.githubusercontent.com/12623986/172843897-da9e240d-3281-4ac3-9299-3d1402542ce8.png)
