### PR TITLE
Add service to refresh materialized view when in development mode

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -62,6 +62,9 @@ services:
   ckan-harvesting-gatherer:
     <<: *partial-ckan-volumes
 
+  # NOTE: This is not suitable for staging or production!
+  # Be sure to setup a k8s periodic job and use this command instead:
+  # `launch-ckan-cli harvester run`
   ckan-harvesting-runner:
     <<: *partial-ckan-volumes
     command: [
@@ -80,7 +83,6 @@ services:
       *partial-email-environment-values
 
   pycsw:
-    image: "geopython/pycsw@sha256:84382cbbd18e9788e9b1bb75299ce24b31403f3b3a4afc036c55c4a96a78cdae"
     environment:
       - PYCSW_SERVER_URL=http://localhost:5001
       - PYCSW_REPOSITORY_DB_USERNAME=ckan-dev
@@ -98,6 +100,20 @@ services:
         target: /home/pycsw/pycsw
         # target: /usr/lib/python3.8/site-packages/pycsw
     command: ["--reload"]
+
+  # NOTE: This is not suitable for staging or production!
+  # Be sure to setup a k8s periodic job and use this command instead:
+  # `launch-ckan-cli dalrrd-emc-dcpr pycsw refresh-materialized-view`
+  pycsw-refresher:
+    <<: *partial-ckan-volumes
+    command: [
+      "launch-ckan-cli",
+      "dalrrd-emc-dcpr",
+      "extra-commands",
+      "refresh-pycsw-materialized-view",
+      "--post-run-delay-seconds",
+      "60"
+    ]
 
   ckan-db:
     environment:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -19,6 +19,8 @@ services:
     image: kartoza/ckanext-dalrrd-emc-dcpr:${CKAN_IMAGE_TAG}
     command: ["launch-ckan-cli", "harvester", "fetch-consumer"]
 
+  # NOTE: This needs to be ran as a periodic command, check the
+  # docker-compose.dev.yml file for additional comment
   ckan-harvesting-runner:
     image: kartoza/ckanext-dalrrd-emc-dcpr:${CKAN_IMAGE_TAG}
     command: ["launch-ckan-cli", "harvester", "run"]
@@ -27,8 +29,7 @@ services:
     image: kartoza/ckanext-dalrrd-emc-dcpr:${CKAN_IMAGE_TAG}
 
   pycsw:
-    # TODO: replace this with an official pycsw docker release
-    image: ricardogsilva/pycsw:9f1ef474
+    image: "geopython/pycsw@sha256:84382cbbd18e9788e9b1bb75299ce24b31403f3b3a4afc036c55c4a96a78cdae"
     volumes:
       - type: bind
         source: $PWD/pycsw/pycsw-config.cfg
@@ -36,6 +37,11 @@ services:
       - type: bind
         source: $PWD/pycsw/pycsw_repository_mappings.py
         target: /etc/pycsw/pycsw_repository_mappings.py
+
+  # NOTE: This needs to be ran as a periodic command, check the
+  # docker-compose.dev.yml file for additional comment
+  pycsw-refresher:
+    image: kartoza/ckanext-dalrrd-emc-dcpr:${CKAN_IMAGE_TAG}
 
   ckan-db:
     image: postgis/postgis:13-3.1


### PR DESCRIPTION
This PR adds an additional `pycsw-refresher` to our stack.

The new service is intended to run on a periodic schedule and ensure the DB materialized view that is used by the system's pycsw service is refreshed in order to contain all existing EMC public records.

### NOTE:

The implementation in this PR includes a custom CLI command that can be invoked by running: `ckan dalrrd-emc-dcpr extra-commands refresh-pycsw.materialized-view` - do not run this in production! This command is included as a workaround for the fact that it is not simple to run periodic services in docker-compose. On k8s there are ways to spawn a job periodically. I left some comments in the docker-compose file to provide a bit more insight on this.

fixes #199