### PR TITLE
Prevent DCPR request owner from participating in the moderation workflow

### DIFF
--- a/ckanext/dalrrd_emc_dcpr/logic/auth/dcpr.py
+++ b/ckanext/dalrrd_emc_dcpr/logic/auth/dcpr.py
@@ -276,6 +276,10 @@ def dcpr_request_nsif_moderate_auth(
         if request_obj.status == DCPRRequestStatus.UNDER_NSIF_REVIEW.value:
             if context["auth_user_obj"].sysadmin:
                 result["success"] = True
+            elif context["auth_user_obj"].id == request_obj.owner_user:
+                result["msg"] = toolkit._(
+                    "The DCPR request owner cannot be involved in the moderation stage"
+                )
             elif context["auth_user_obj"].id == request_obj.nsif_reviewer:
                 result["success"] = True
             else:
@@ -302,6 +306,10 @@ def dcpr_request_csi_moderate_auth(
         if request_obj.status == DCPRRequestStatus.UNDER_CSI_REVIEW.value:
             if context["auth_user_obj"].sysadmin:
                 result["success"] = True
+            elif context["auth_user_obj"].id == request_obj.owner_user:
+                result["msg"] = toolkit._(
+                    "The DCPR request owner cannot be involved in the moderation stage"
+                )
             elif context["auth_user_obj"].id == request_obj.csi_moderator:
                 result["success"] = True
             else:
@@ -352,6 +360,10 @@ def dcpr_request_claim_nsif_reviewer_auth(
     if request_obj is not None:
         if context["auth_user_obj"].sysadmin:
             result["success"] = True
+        elif context["auth_user_obj"].id == request_obj.owner_user:
+            result["msg"] = toolkit._(
+                "The DCPR request owner cannot be involved in the moderation stage"
+            )
         else:
             is_nsif_member = toolkit.h["emc_user_is_org_member"](
                 NSIF_ORG_NAME, context["auth_user_obj"]
@@ -383,6 +395,10 @@ def dcpr_request_claim_csi_moderator_auth(
     if request_obj is not None:
         if context["auth_user_obj"].sysadmin:
             result["success"] = True
+        elif context["auth_user_obj"].id == request_obj.owner_user:
+            result["msg"] = toolkit._(
+                "The DCPR request owner cannot be involved in the moderation stage"
+            )
         else:
             is_csi_member = toolkit.h["emc_user_is_org_member"](
                 CSI_ORG_NAME, context["auth_user_obj"]

--- a/ckanext/dalrrd_emc_dcpr/templates/dcpr/show.html
+++ b/ckanext/dalrrd_emc_dcpr/templates/dcpr/show.html
@@ -77,7 +77,7 @@
             {# TODO: Add the dataset custodian info #}
             <tr>
                 <th scope="row" class="dataset-label">{{ _('Status') }} </th>
-                <td>{{ dcpr_request.status }}</td>
+                <td><span class="label label-default">{{ dcpr_request.status }}</span></td>
             </tr>
             <tr>
                 <th scope="row" class="dataset-label">{{ _("Additional project context") }}</th>


### PR DESCRIPTION
This PR adds some additional logic checks in the DCPR authorization functions that prevents a DCPR request owner from becoming a NSIF or CSI moderator and also prevent the user from submitting any moderation too.

fixes #191