### PR TITLE
Fix regression with creation of metadata records

### DIFF
--- a/ckanext/dalrrd_emc_dcpr/cli/__init__.py
+++ b/ckanext/dalrrd_emc_dcpr/cli/__init__.py
@@ -2,7 +2,7 @@ import dataclasses
 import logging
 import typing
 import uuid
-from collections.abc import Iterable
+import collections.abc
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -219,7 +219,9 @@ class _CkanExtBootstrapPage:
 def _to_data_dict(value):
     if isinstance(value, (str, int, float)):
         result = value
-    elif isinstance(value, Iterable):
+    elif isinstance(value, collections.abc.Mapping):
+        result = value
+    elif isinstance(value, collections.abc.Iterable):
         result = [_to_data_dict(i) for i in value]
     elif getattr(value, "to_data_dict", None) is not None:
         result = value.to_data_dict()

--- a/ckanext/dalrrd_emc_dcpr/cli/utils.py
+++ b/ckanext/dalrrd_emc_dcpr/cli/utils.py
@@ -43,7 +43,7 @@ def create_single_dataset(
         toolkit.get_action("package_create")({"user": user["name"]}, data_dict=dataset)
         result = DatasetCreationResult.CREATED
     else:
-        # logger.debug(f"dataset {dataset['name']!r} already exists, skipping...")
+        logger.debug(f"dataset {dataset['name']!r} already exists, skipping...")
         result = DatasetCreationResult.NOT_CREATED_ALREADY_EXISTS
     if close_session:
         model.Session.remove()

--- a/ckanext/dalrrd_emc_dcpr/logic/converters.py
+++ b/ckanext/dalrrd_emc_dcpr/logic/converters.py
@@ -11,7 +11,6 @@ def emc_bbox_converter(value: str) -> str:
         "Invalid bounding box. Please provide a comma-separated list of values "
         "with upper left lat, upper left lon, lower right lat, lower right lon."
     )
-    logger.debug(f"inside emc_bbox_converter {value=}")
     try:  # is it already a geojson?
         parsed_value = json.loads(value)
         coordinates = parsed_value["coordinates"][0]
@@ -45,5 +44,4 @@ def emc_bbox_converter(value: str) -> str:
             ]
         ],
     }
-    logger.debug(f"{parsed=}")
     return json.dumps(parsed)


### PR DESCRIPTION
This PR fixes a recent regression in the creation of metadata records.

The parsing of fields was incorrectly generating lists instead of dicts for some of the dataset properties.

fixes #203