### PR TITLE
Update NSIF reviewer permission in moderating DCPR requests

### DIFF
--- a/ckanext/dalrrd_emc_dcpr/logic/action/dcpr/update.py
+++ b/ckanext/dalrrd_emc_dcpr/logic/action/dcpr/update.py
@@ -192,7 +192,6 @@ def dcpr_request_nsif_moderate(
             context["model"].Session.commit()
             activity_type = {
                 DcprRequestModerationAction.APPROVE: DcprManagementActivityType.ACCEPT_DCPR_REQUEST_NSIF,
-                DcprRequestModerationAction.REJECT: DcprManagementActivityType.REJECT_DCPR_REQUEST_NSIF,
                 DcprRequestModerationAction.REQUEST_CLARIFICATION: DcprManagementActivityType.REQUEST_CLARIFICATION_DCPR_REQUEST_NSIF,
             }[moderation_action]
             activity = create_dcpr_management_activity(

--- a/ckanext/dalrrd_emc_dcpr/logic/auth/dcpr.py
+++ b/ckanext/dalrrd_emc_dcpr/logic/auth/dcpr.py
@@ -3,7 +3,12 @@ import typing
 
 from ckan.plugins import toolkit
 from ...model import dcpr_request as dcpr_request
-from ...constants import DcprRequestModerationAction, DCPRRequestStatus, CSI_ORG_NAME, NSIF_ORG_NAME
+from ...constants import (
+    DcprRequestModerationAction,
+    DCPRRequestStatus,
+    CSI_ORG_NAME,
+    NSIF_ORG_NAME,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -279,7 +284,8 @@ def dcpr_request_nsif_moderate_auth(
             elif context["auth_user_obj"].id == request_obj.nsif_reviewer:
                 try:
                     moderate_action = DcprRequestModerationAction(
-                        data_dict.get("action"))
+                        data_dict.get("action")
+                    )
                 except ValueError:
                     moderate_action = None
 

--- a/ckanext/dalrrd_emc_dcpr/logic/auth/dcpr.py
+++ b/ckanext/dalrrd_emc_dcpr/logic/auth/dcpr.py
@@ -3,7 +3,7 @@ import typing
 
 from ckan.plugins import toolkit
 from ...model import dcpr_request as dcpr_request
-from ...constants import DCPRRequestStatus, CSI_ORG_NAME, NSIF_ORG_NAME
+from ...constants import DcprRequestModerationAction, DCPRRequestStatus, CSI_ORG_NAME, NSIF_ORG_NAME
 
 logger = logging.getLogger(__name__)
 
@@ -277,7 +277,18 @@ def dcpr_request_nsif_moderate_auth(
                     "The DCPR request owner cannot be involved in the moderation stage"
                 )
             elif context["auth_user_obj"].id == request_obj.nsif_reviewer:
-                result["success"] = True
+                try:
+                    moderate_action = DcprRequestModerationAction(
+                        data_dict.get("action"))
+                except ValueError:
+                    moderate_action = None
+
+                if moderate_action == DcprRequestModerationAction.REJECT:
+                    result["msg"] = toolkit._(
+                        "NSIF reviewers are not authorized to reject a DCPR request."
+                    )
+                else:
+                    result["success"] = True
             else:
                 result["msg"] = toolkit._(
                     "Current user is not authorized to moderate this DCPR request on "

--- a/ckanext/dalrrd_emc_dcpr/templates/dcpr/moderate.html
+++ b/ckanext/dalrrd_emc_dcpr/templates/dcpr/moderate.html
@@ -13,7 +13,6 @@
                 <form id='dcpr-request-confirmation-form' action="{{ action_url }}" method="post">
                     <button class="btn btn-default" type="submit" name="REQUEST_CLARIFICATION" >{{ _('Move back to draft') }}</button>
                     <button class="btn btn-primary" type="submit" name="APPROVE" >{{ _('Approve DCPR request') }}</button>
-                    <button class="btn btn-default" type="submit" name="REJECT" >{{ _('Reject DCPR Request') }}</button>
                 </form>
             </p>
         </div>


### PR DESCRIPTION
Fixes https://github.com/kartoza/ckanext-dalrrd-emc-dcpr/issues/210

These changes removes the ability of the NSIF representative to reject a DCPR request when moderating it.