### PR TITLE
Include NSIF and CSI representatives information in the DCPR request details page

### DIFF
--- a/ckanext/dalrrd_emc_dcpr/blueprints/dcpr.py
+++ b/ckanext/dalrrd_emc_dcpr/blueprints/dcpr.py
@@ -347,6 +347,30 @@ def dcpr_request_show(csi_reference_id):
         extra_vars = {
             "dcpr_request": dcpr_request,
         }
+        context = _prepare_context()
+        model = context["model"]
+
+        if dcpr_request.get("owner_user") == context[
+            "auth_user_obj"
+        ].id and dcpr_request.get("status") in [
+            constants.DCPRRequestStatus.UNDER_NSIF_REVIEW.value,
+            constants.DCPRRequestStatus.UNDER_CSI_REVIEW.value,
+        ]:
+
+            target_user_role = {
+                constants.DCPRRequestStatus.UNDER_NSIF_REVIEW.value: "nsif_reviewer",
+                constants.DCPRRequestStatus.UNDER_CSI_REVIEW.value: "csi_moderator",
+            }[dcpr_request.get("status")]
+
+            current_reviewer = (
+                model.User.get(dcpr_request.get(target_user_role))
+                if dcpr_request.get(target_user_role)
+                else None
+            )
+
+            if current_reviewer:
+                extra_vars["current_reviewer"] = current_reviewer
+
         result = toolkit.render("dcpr/show.html", extra_vars=extra_vars)
     return result
 

--- a/ckanext/dalrrd_emc_dcpr/templates/dcpr/show.html
+++ b/ckanext/dalrrd_emc_dcpr/templates/dcpr/show.html
@@ -79,6 +79,16 @@
                 <th scope="row" class="dataset-label">{{ _('Status') }} </th>
                 <td><span class="label label-default">{{ dcpr_request.status }}</span></td>
             </tr>
+            {% if current_reviewer %}
+            <tr>
+                <th scope="row" class="dataset-label">{{ _('Current reviewer name') }} </th>
+                <td>{{ current_reviewer.name }}</td>
+            </tr>
+            <tr>
+                <th scope="row" class="dataset-label">{{ _('Current reviewer contact') }} </th>
+                <td>{{ current_reviewer.email }}</td>
+            </tr>
+            {% endif %}
             <tr>
                 <th scope="row" class="dataset-label">{{ _("Additional project context") }}</th>
                 <td class="dataset-details">


### PR DESCRIPTION
Fixes https://github.com/kartoza/ckanext-dalrrd-emc-dcpr/issues/194

Adds the current NSIF and CSI representatives name and email in the DCPR request details page, as noted in the original issue these details will only be shown to the owner/author of the corresponding DCPR request.

Screenshot of the new DCPR request information
![current_reviewer_details_emc](https://user-images.githubusercontent.com/2663775/176174385-4494649d-a085-4ff4-9541-9f110854dfe5.png)
