### PR TITLE
adding redirection to DCPR request facet

### DIFF
--- a/ckanext/dalrrd_emc_dcpr/assets/js/facetsActive.js
+++ b/ckanext/dalrrd_emc_dcpr/assets/js/facetsActive.js
@@ -39,3 +39,27 @@ ckan.module('emc-factes-avtive', function (jQuery, _) {
     }
 
 })
+
+// =====================
+/**
+    as the dcpr_request has a public page,
+    facet only need to change the window
+    location to the dcpr requests public
+    page.
+*/
+
+ckan.module("dcpr_request_facet", function($){
+    return{
+        initialize:function(){
+            $.proxyAll(this,/_on/);
+            this.el.on("click", this._onClick)
+        },
+
+        _onClick:function(){
+            let text = this.el.text()
+            if(text.toLowerCase().indexOf("dcpr request") != -1){
+                window.location.href = window.location.origin + '/dcpr/'
+            }
+        }
+    }
+})

--- a/ckanext/dalrrd_emc_dcpr/templates/snippets/facet_list.html
+++ b/ckanext/dalrrd_emc_dcpr/templates/snippets/facet_list.html
@@ -28,7 +28,7 @@
             <div class="panel panel-default">
                 <div class="panel-heading" role="tab" id="head{{ item_id }}">
                   <h2 class="panel-title">
-                    <a role="button" data-toggle="collapse" data-parent="#accordion" href="#{{ item_id }}" aria-expanded="true" aria-controls="{{ item_id }}">
+                    <a role="button" data-toggle="collapse" data-parent="#accordion" href="#{{ item_id }}" aria-expanded="true" aria-controls="{{ item_id }}" data-module="dcpr_request_facet">
                       <i class="{{ filters[title] }}"></i>
                         {% set title = title or h.get_facet_title(name) %}
                         {{ title }}


### PR DESCRIPTION
once the user clicks on the DCPR request facet, they will be taken to the public DCPR requests.