### PR TITLE
showing dcpr request links based on access permissions

### DIFF
--- a/ckanext/dalrrd_emc_dcpr/assets/js/facetsActive.js
+++ b/ckanext/dalrrd_emc_dcpr/assets/js/facetsActive.js
@@ -39,27 +39,3 @@ ckan.module('emc-factes-avtive', function (jQuery, _) {
     }
 
 })
-
-// =====================
-/**
-    as the dcpr_request has a public page,
-    facet only need to change the window
-    location to the dcpr requests public
-    page.
-*/
-
-ckan.module("dcpr_request_facet", function($){
-    return{
-        initialize:function(){
-            $.proxyAll(this,/_on/);
-            this.el.on("click", this._onClick)
-        },
-
-        _onClick:function(){
-            let text = this.el.text()
-            if(text.toLowerCase().indexOf("dcpr request") != -1){
-               // window.location.href = window.location.origin + '/dcpr/'
-            }
-        }
-    }
-})

--- a/ckanext/dalrrd_emc_dcpr/helpers.py
+++ b/ckanext/dalrrd_emc_dcpr/helpers.py
@@ -227,6 +227,21 @@ def get_recently_modified_datasets():
     return result["results"]
 
 
+def get_all_datasets_count(user_obj):
+    """
+    fixes a bug when applying
+    solr active search
+    https://github.com/kartoza/ckanext-dalrrd-emc-dcpr/issues/116
+    """
+    search_action = toolkit.get_action("package_search")
+    # 32000 rows is the maximum of what can be retrieved
+    # by ckan at once.
+    result = search_action(
+        context={"user": user_obj.id}, data_dict={"q": "*:*", "rows": 32000}
+    )
+    return result["count"]
+
+
 def _pad_geospatial_extent(extent: typing.Dict, padding: float) -> typing.Dict:
     geom = geometry.shape(extent)
     padded = geom.buffer(padding, join_style=geometry.JOIN_STYLE.mitre)

--- a/ckanext/dalrrd_emc_dcpr/helpers.py
+++ b/ckanext/dalrrd_emc_dcpr/helpers.py
@@ -236,9 +236,14 @@ def get_all_datasets_count(user_obj):
     search_action = toolkit.get_action("package_list")
     # 32000 rows is the maximum of what can be retrieved
     # by ckan at once.
-    result = search_action(context={"user": user_obj.id}, data_dict={})
-    package_count = len(result)
-    return package_count
+    if user_obj is not None:
+        result = search_action(context={"user": user_obj.id}, data_dict={})
+        package_count = len(result)
+        return package_count
+    else:
+        result = search_action(data_dict={})
+        package_count = len(result)
+        return package_count
 
 
 def _pad_geospatial_extent(extent: typing.Dict, padding: float) -> typing.Dict:

--- a/ckanext/dalrrd_emc_dcpr/helpers.py
+++ b/ckanext/dalrrd_emc_dcpr/helpers.py
@@ -233,13 +233,12 @@ def get_all_datasets_count(user_obj):
     solr active search
     https://github.com/kartoza/ckanext-dalrrd-emc-dcpr/issues/116
     """
-    search_action = toolkit.get_action("package_search")
+    search_action = toolkit.get_action("package_list")
     # 32000 rows is the maximum of what can be retrieved
     # by ckan at once.
-    result = search_action(
-        context={"user": user_obj.id}, data_dict={"q": "*:*", "rows": 32000}
-    )
-    return result["count"]
+    result = search_action(context={"user": user_obj.id}, data_dict={})
+    package_count = len(result)
+    return package_count
 
 
 def _pad_geospatial_extent(extent: typing.Dict, padding: float) -> typing.Dict:

--- a/ckanext/dalrrd_emc_dcpr/plugins/emc_dcpr_plugin.py
+++ b/ckanext/dalrrd_emc_dcpr/plugins/emc_dcpr_plugin.py
@@ -353,6 +353,7 @@ class DalrrdEmcDcprPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
             ] = toolkit._("ISO Topic Category")
             facets_dict["reference_date"] = toolkit._("Reference Date")
             facets_dict["harvest_source_title"] = toolkit._("Harvest source")
+            facets_dict["dcpr_request"] = toolkit._("DCPR Request")
         return facets_dict
 
     def group_facets(

--- a/ckanext/dalrrd_emc_dcpr/plugins/emc_dcpr_plugin.py
+++ b/ckanext/dalrrd_emc_dcpr/plugins/emc_dcpr_plugin.py
@@ -328,6 +328,7 @@ class DalrrdEmcDcprPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
             "emc_user_is_staff_member": helpers.user_is_staff_member,
             "emc_get_featured_datasets": helpers.get_featured_datasets,
             "emc_get_recently_modified_datasets": helpers.get_recently_modified_datasets,
+            "emc_get_all_datasets_count": helpers.get_all_datasets_count,
             "dcpr_get_next_intermediate_dcpr_request_status": helpers.get_next_intermediate_dcpr_status,
             "dcpr_user_is_dcpr_request_owner": helpers.user_is_dcpr_request_owner,
             "emc_org_memberships": helpers.get_org_memberships,

--- a/ckanext/dalrrd_emc_dcpr/templates/package/search.html
+++ b/ckanext/dalrrd_emc_dcpr/templates/package/search.html
@@ -2,7 +2,7 @@
 
 {% block breadcrumb_content %}
     <div class="page-header">
-    {% set total =  page.item_count %}
+    {% set total =  h.emc_get_all_datasets_count(g.userobj) %}
         <h1>Electronic Metadata Catalogue (EMC)</h1>
         <h5>Total number of datasets: {{ total }}</h5>
         <h5>{{ page.item_count }} datasets found</h5>

--- a/ckanext/dalrrd_emc_dcpr/templates/snippets/facet_list.html
+++ b/ckanext/dalrrd_emc_dcpr/templates/snippets/facet_list.html
@@ -23,8 +23,7 @@
                         'SASDI Theme': 'fa fa-tasks',
                         'ISO Topic Category': 'fa fa-filter',
                         'Harvest source': 'fa fa-cloud',
-						'DCPR Request': 'fa fa-file'
-
+						'DCPR Request': 'fa fa-file',
                     } %}
             <div class="panel panel-default">
                 <div class="panel-heading" role="tab" id="head{{ item_id }}">
@@ -43,25 +42,41 @@
                 <div id="{{ item_id }}" class="panel-collapse collapse" role="tabpanel" aria-labelledby="{{ item_id }}">
                 <div class="panel-body">
 			{% with items = items or h.get_facet_items_dict(name, search_facets or c.search_facets) %}
-			{% if item_id == 'DCPRRequest' %}
-			{% set items = {'Public requests':"", 'My requests':"my-dcpr-requests", 'Requests awaiting NSIF moderation':"awaiting-nsif-moderation-dcpr-requests", 'Requests awaiting CSI moderation':"awaiting-csi-moderation-dcpr-requests", 'Requests under preparation':"under-preparation-dcpr-requests"} %}
-			{% endif %}
+				{% if item_id == 'DCPRRequest' %}
+					{% set items = {'Public requests':{"link":"", "access":"dcpr_request_list_public_auth"},
+					'My requests':{"link":"my-dcpr-requests", "access":"my_dcpr_request_list_auth"},
+					'Requests awaiting NSIF moderation':{"link":"awaiting-nsif-moderation-dcpr-requests", "access":"dcpr_request_list_pending_nsif_auth"},
+					'Requests awaiting CSI moderation':{"link":"awaiting-csi-moderation-dcpr-requests", "access":"dcpr_request_list_pending_csi_auth"},
+					'Requests under preparation':{"link":"under-preparation-dcpr-requests", "access":"dcpr_request_list_under_preparation_auth"}}
+					 %}
+				{% endif %}
 			{% if items %}
 				<nav aria-label="{{ title }}">
 				    <ul class="{{ nav_class or 'list-unstyled nav nav-simple nav-facet' }}">
 						{% for item in items %}
-						{% if item_id == 'DCPRRequest' %}
-						{% set href = request.url_root + "dcpr/" + items[item]%}
-						{% set label = item %}
-						{% set label_truncated = h.truncate(label, 22) %}
-						{% set count = '' %}
+							{% if item_id == 'DCPRRequest' %}
+							{# apply the check here #}
+							{% set href = request.url_root + "dcpr/" + items[item]["link"]%}
+							{% set label = item %}
+							{% set label_truncated = h.truncate(label, 22) %}
+							{% set count = '' %}
+							{% if not h.check_access(items[item]['access']) %}
+
+							{% else %}
+							<li class="{{ nav_item_class or 'nav-item' }}{% if item.active %} active{% endif %}">
+							<a href="{{ href }}" title="{{ label if label != label_truncated else '' }}" data-module="emc-factes-avtive">
+								<span class="item-label">{{ label_truncated }}</span>
+								<span class="hidden separator"> - </span>
+								<span class="item-count badge">{{ count }}</span>
+							</a>
+							</li>
+							{% endif %}
 						{% else %}
-					    {% set href = h.remove_url_param(name, item.name, extras=extras, alternative_url=alternative_url) if item.active else h.add_url_param(new_params={name: item.name}, extras=extras, alternative_url=alternative_url) %}
-					    {% set label = label_function(item) if label_function else item.display_name %}
-					    {% set label_truncated = h.truncate(label, 22) if not label_function else label %}
-					    {% set count = count_label(item['count']) if count_label else ('%d' % item['count']) %}
-						{% endif %}
-						{# comment to update the head#}
+					    	{% set href = h.remove_url_param(name, item.name, extras=extras, alternative_url=alternative_url) if item.active else h.add_url_param(new_params={name: item.name}, extras=extras, alternative_url=alternative_url) %}
+					    	{% set label = label_function(item) if label_function else item.display_name %}
+					    	{% set label_truncated = h.truncate(label, 22) if not label_function else label %}
+					    	{% set count = count_label(item['count']) if count_label else ('%d' % item['count']) %}
+
 						<li class="{{ nav_item_class or 'nav-item' }}{% if item.active %} active{% endif %}">
 						<a href="{{ href }}" title="{{ label if label != label_truncated else '' }}" data-module="emc-factes-avtive">
 						    <span class="item-label">{{ label_truncated }}</span>
@@ -69,10 +84,10 @@
 						    <span class="item-count badge">{{ count }}</span>
 						</a>
 					    </li>
+						{% endif %}
 					{% endfor %}
 				    </ul>
 				</nav>
-
 				<p class="module-footer">
 				    {% if h.get_param_int('_%s_limit' % name) %}
 					{% if h.has_more_facets(name, search_facets or c.search_facets) %}


### PR DESCRIPTION
@Samweli @Fanevanjanahary based on your previous review, i've adjusted the facets regarding dcpr requests to show links only when the user is permitted to show relative section, check the below examples:
1. the user is an admin and able to follow all links:

![Screenshot from 2022-07-18 22-43-13](https://user-images.githubusercontent.com/58084234/179615607-da28837c-f07a-4676-bfbb-e13c46ed1ef3.png)

2. users are random testers and have permission to list public requests and requests made by themselves 
![Screenshot from 2022-07-18 22-44-47](https://user-images.githubusercontent.com/58084234/179615530-e5d96a65-25b8-4189-93b5-eb94616b51da.png)

