### PR TITLE
dataset count change package_list to database query

### DIFF
--- a/ckanext/dalrrd_emc_dcpr/helpers.py
+++ b/ckanext/dalrrd_emc_dcpr/helpers.py
@@ -236,14 +236,17 @@ def get_all_datasets_count(user_obj):
     search_action = toolkit.get_action("package_list")
     # 32000 rows is the maximum of what can be retrieved
     # by ckan at once.
-    if user_obj is not None:
-        result = search_action(context={"user": user_obj.id}, data_dict={})
-        package_count = len(result)
-        return package_count
-    else:
-        result = search_action(data_dict={})
-        package_count = len(result)
-        return package_count
+    q = """ select count(distinct(id)) from package where state='active' """
+    result = model.Session.execute(q)
+    return result.fetchone()[0]
+    # if user_obj is not None:
+    #     result = search_action(context={"user": user_obj.id}, data_dict={})
+    #     package_count = len(result)
+    #     return package_count
+    # else:
+    #     result = search_action(data_dict={})
+    #     package_count = len(result)
+    #     return package_count
 
 
 def _pad_geospatial_extent(extent: typing.Dict, padding: float) -> typing.Dict:


### PR DESCRIPTION
changed the way the dataset count happens, using package_list will take auth under consideration, when need to reflect all the datasets in the site, private or not.