### PR TITLE
handling type error with the testing site

### DIFF
--- a/ckanext/dalrrd_emc_dcpr/templates/dcpr/snippets/info.html
+++ b/ckanext/dalrrd_emc_dcpr/templates/dcpr/snippets/info.html
@@ -8,7 +8,8 @@
         <div class="panel-body">
             <p>The Data Capture Project Registry (DCPR) contains a listing of all data capture requests</p>
             <p>Creation of new DCPR requests is reserved for authenticated users that are members of an EMC organization.</p>
-          </div>
+            <p>More information about the DCPR can be found in the <a href="{{ url_for('pages.show', page='help#dcpr') }}">Help page, DCPR section<a></p>
+        </div>
     </div>
 </section>
 

--- a/ckanext/dalrrd_emc_dcpr/templates/scheming/display_snippets/modified_repeating_subfields.html
+++ b/ckanext/dalrrd_emc_dcpr/templates/scheming/display_snippets/modified_repeating_subfields.html
@@ -1,5 +1,3 @@
-
-
 {% set fields = data[field.field_name] %}
 
 {% block subfield_display %}

--- a/ckanext/dalrrd_emc_dcpr/templates/scheming/form_snippets/modified_repeating_subfields.html
+++ b/ckanext/dalrrd_emc_dcpr/templates/scheming/form_snippets/modified_repeating_subfields.html
@@ -30,7 +30,7 @@
   </div>
 {% endmacro %}
 
-{% set flat = h.scheming_flatten_subfield(field, data) %}
+<!-- {% set flat = h.scheming_flatten_subfield(field, data) %} -->
 {% set flaterr = h.scheming_flatten_subfield(field, errors) %}
 
 {% call form.input_block(


### PR DESCRIPTION
as there were new fields added to the dataset form, a type error is raised when managing the dataset - press "manage" button - this is handled by removing {% set flat = h.scheming_flatten_subfield(field, data) %} from the modified_repeating_subfields.html found in scheming form form_snippets, this helper function is defined here https://github.com/ckan/ckanext-scheming/blob/master/ckanext/scheming/helpers.py#L414, it changes the subfields keys appearing in the repeating subfields data into standardized (refer to the provided link for more details) format, won't need this functionality as with all modified repeating subfields, we are just having one repeating subfield (without them repeating, thus something as field_name-1-subfield won't be needed). 
screenshot about the error:
![Screenshot from 2022-08-31 21-05-59](https://user-images.githubusercontent.com/58084234/187762803-2557c818-d729-40f4-8cd7-9cfb6432a4b2.png)
