### PR TITLE
adding buffer search

### DIFF
--- a/ckanext/dalrrd_emc_dcpr/assets/js/datasetSpatialExtentMap.js
+++ b/ckanext/dalrrd_emc_dcpr/assets/js/datasetSpatialExtentMap.js
@@ -94,7 +94,7 @@ ckan.module("emcDatasetSpatialExtentMap", function(jQuery, _){
         },
 
         _onCreate: function (event) {
-            console.log("Created new")
+            // console.log("Created new")
             event.layer.on("pm:edit", this._onLayerEdit)
             event.layer.on("pm:dragend", this._onLayerDrag)
             this.formInputElement.setAttribute("value", this._getBboxString(event.layer.getBounds()))
@@ -102,7 +102,7 @@ ckan.module("emcDatasetSpatialExtentMap", function(jQuery, _){
         },
 
         _onDrawStart: function (event) {
-            console.log("Started drawing")
+            // console.log("Started drawing")
             this.map.removeLayer(this.rectangleLayer)
         },
 

--- a/ckanext/dalrrd_emc_dcpr/assets/js/spatial_search.js
+++ b/ckanext/dalrrd_emc_dcpr/assets/js/spatial_search.js
@@ -50,7 +50,33 @@ ckan.module("spatial_search", function($){
                 })
                 let layerControl = L.control.layers(null,divisions_overlay)
                 layerControl.addTo(Lmap);
-            }
+                // adding circle to leaflet draw
+                $("a.leaflet-draw-draw-rectangle").parent().append(
+                    $("<a class='leaflet-draw-draw-circle'></a>")
+                )
+
+                $('a.leaflet-draw-draw-circle').hover(function(e){
+                    $(this).css({"cursor":"pointer"})
+                })
+
+                $('a.leaflet-draw-draw-circle').on('click', function(e){
+                    // if($('body').hasClass('dataset-map-expanded')){
+                    //     $('body').removeClass('dataset-map-expanded');
+                    // }
+                    // else{
+                    //     $('body').addClass('dataset-map-expanded');
+                    // }
+                    $('body').toggleClass('dataset-map-expanded');
+                    let drawer = new L.Draw.Circle(Lmap)
+                    drawer.enable()
+                  });
+
+                  Lmap.on('draw:created', function (e) {
+                    layer = e.layer;
+                    layer.addTo(Lmap);
+                    $('#ext_bbox').val(layer.getBounds().toBBoxString());
+                });
+                }
         },
     }
 })


### PR DESCRIPTION
the user can now add search radius instead of only having a rectangle, boundaries will be calculated from this radius and the search would apply.
![radius buffer search](https://user-images.githubusercontent.com/58084234/189225165-574d34b4-9e20-4e60-b9d6-cf15163229d0.png)
![radius buffer search 2](https://user-images.githubusercontent.com/58084234/189225180-ed40a621-12da-460b-b37b-f825a0c1e7ce.png)
