### PR TITLE
adding spatial bounds to dataset creation form

### DIFF
--- a/ckanext/dalrrd_emc_dcpr/assets/css/dataset-spatial-extent-map.css
+++ b/ckanext/dalrrd_emc_dcpr/assets/css/dataset-spatial-extent-map.css
@@ -8,3 +8,8 @@
     height: 300px;
     width: 100%;
 }
+
+.leaflet-control-layers-overlays > label::after{
+    /* removing the colons ":" from lealfet layers names */
+    content: "" !important;
+}

--- a/ckanext/dalrrd_emc_dcpr/assets/js/spatial_search.js
+++ b/ckanext/dalrrd_emc_dcpr/assets/js/spatial_search.js
@@ -7,6 +7,7 @@ ckan.module("spatial_search", function($){
             $.proxyAll(this,/_on/);
         },
         mapper: function(){
+            var _this = this
             let Lmap = window.map
             if(Lmap == undefined){
                 setTimeout(this.mapper,1500)
@@ -17,10 +18,12 @@ ckan.module("spatial_search", function($){
                    one of them is rejected keeps me of using it.
                    at the same time we don't want to sequence these */
 
-                 let divisions = ["national", "provinces", "district_municipalities", "local_municipalities"]
+                let divisions = ["national", "provinces", "district_municipalities", "local_municipalities"]
                 let divisions_overlay = {}
                 divisions.forEach(division =>{
-                    divisions_overlay[division] = L.layerGroup()
+                    let _caps = division.charAt(0).toUpperCase() + division.slice(1);
+                    var division_caps = _caps.replace("_", " ")
+                    divisions_overlay[division_caps] = L.layerGroup()
                     let division_json = L.geoJson(null,{
                         onEachFeature:function(feature, layer){
 
@@ -46,7 +49,7 @@ ckan.module("spatial_search", function($){
                     data.features.forEach(item=>{
                         division_json.addData(item)
                     })
-                }).then(divisions_overlay[division].addLayer(division_json))
+                }).then(divisions_overlay[division_caps].addLayer(division_json))
                 })
                 let layerControl = L.control.layers(null,divisions_overlay)
                 layerControl.addTo(Lmap);
@@ -76,7 +79,11 @@ ckan.module("spatial_search", function($){
                     layer.addTo(Lmap);
                     $('#ext_bbox').val(layer.getBounds().toBBoxString());
                 });
-                }
+            }
         },
+        captializeFirstLetter: function(name){
+            return
+        },
+
     }
 })

--- a/ckanext/dalrrd_emc_dcpr/templates/base.html
+++ b/ckanext/dalrrd_emc_dcpr/templates/base.html
@@ -4,6 +4,7 @@
 {#    {{ super() }}#}
     {% asset 'ckanext-dalrrdemcdcpr/ckan-base-css' %}
     {% asset 'ckanext-dalrrdemcdcpr/dalrrd-emc-dcpr-css' %}
+    {% asset 'ckanext-dalrrdemcdcpr/dataset-spatial-extent-map-css' %}
 {% endblock %}
 
 {% block scripts %}


### PR DESCRIPTION
per sprint meeting - September 16th -2022, South Africa boundaries were added to metadata record creation form, few fixes were added to the spatial search map with boundaries naming.
![Screenshot from 2022-09-21 11-38-28](https://user-images.githubusercontent.com/58084234/191472153-cd897462-2771-430a-b9b9-a4a06411c43e.png)
![Screenshot from 2022-09-21 11-37-49](https://user-images.githubusercontent.com/58084234/191472291-07439f37-f7ce-44d7-bfba-ca47cace5196.png)
