### PR TITLE
removing repeated world from leaflet

### DIFF
--- a/ckanext/dalrrd_emc_dcpr/assets/js/spatial_search.js
+++ b/ckanext/dalrrd_emc_dcpr/assets/js/spatial_search.js
@@ -31,6 +31,11 @@ ckan.module("spatial_search", function($){
                 setTimeout(this.mapper,1500)
             }
             else{
+            Lmap.eachLayer(lyr=>{
+                if( lyr instanceof L.TileLayer ) {
+                    lyr.options.noWrap = true
+                }
+            })
                 let divisions = ["national", "provinces", "district_municipalities", "local_municipalities"]
                 let divisions_overlay = {}
                 divisions.forEach(division =>{


### PR DESCRIPTION
fix #359, the leaflet map will display grey area outside the world extent.

![leaflet grey area outside world extent](https://user-images.githubusercontent.com/58084234/198898730-44b87521-671a-409a-b640-4dfe4c3a2a6b.png)
