### PR TITLE
limit search map to SA bounds

### DIFF
--- a/ckanext/dalrrd_emc_dcpr/assets/js/spatial_search.js
+++ b/ckanext/dalrrd_emc_dcpr/assets/js/spatial_search.js
@@ -28,9 +28,19 @@ ckan.module("spatial_search", function($){
                 return division_caps
             }
             if(Lmap == undefined){
-                setTimeout(this.mapper,1500)
+                setTimeout(this.mapper,1500);
             }
             else{
+                bound1 = L.latLng(-34.921971, 9.580078)
+                bound2 = L.latLng(-21.002471, 37.001953)
+                Lmap.setMaxBounds([
+                    bound1, bound2
+                    ])
+
+                Lmap.options.minZoom = 4;
+
+
+
             Lmap.eachLayer(lyr=>{
                 if( lyr instanceof L.TileLayer ) {
                     lyr.options.noWrap = true

--- a/cypress/integration/search/search_by_org.cy.js
+++ b/cypress/integration/search/search_by_org.cy.js
@@ -1,0 +1,25 @@
+/*
+this test fails because
+the facet active javascript
+file is not loaded correctly
+with selected orgranization page.
+TODO: further investigate why
+the module is not correctly
+imported
+*/
+
+
+describe("searching datasets by organizations", ()=>{
+
+    beforeEach(()=>{
+        cy.visit("/dataset/")
+    })
+
+    it("search datasets by organization", ()=>{
+        cy.get("a").contains("Organisations").click()
+        .get("a[href='/organization/csi']").click()
+        .get(".dataset-item").its("length").should("gt",0)
+    })
+
+
+})

--- a/cypress/integration/search/search_by_theme.cy copy.js
+++ b/cypress/integration/search/search_by_theme.cy copy.js
@@ -1,0 +1,16 @@
+
+describe("searching datasets by SASDI themes", ()=>{
+
+    beforeEach(()=>{
+        cy.visit("/dataset/")
+    })
+
+    it("search datasets by organization", ()=>{
+        cy.get("#headSASDIThemes")
+        .click()
+        .get("#SASDIThemes").click()
+        .get(".dataset-item").its("length").should("gt",0)
+    })
+
+
+})

--- a/cypress/integration/search/search_by_theme.cy.js
+++ b/cypress/integration/search/search_by_theme.cy.js
@@ -1,0 +1,16 @@
+
+describe("searching datasets by SASDI themes", ()=>{
+
+    beforeEach(()=>{
+        cy.visit("/dataset/")
+    })
+
+    it("search datasets by organization", ()=>{
+        cy.get("#headSASDIThemes")
+        .click()
+        .get("#SASDIThemes").click()
+        .get(".dataset-item").its("length").should("gt",0)
+    })
+
+
+})


### PR DESCRIPTION
once the map is loaded, zooming and panning capabilities will be limited to SA bounds, see the gif below
this address #361 , @gubuntu comment https://github.com/kartoza/ckanext-dalrrd-emc-dcpr/pull/361#issuecomment-1296768651, and  #359 
![map limited bounds](https://user-images.githubusercontent.com/58084234/199836276-78d26ad8-f51c-4782-a330-5335aabac3e5.gif)
