### PR TITLE
get release tags on the footer

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,4 +26,5 @@ repos:
           - types-python-dateutil==2.8.9
           - types-python-slugify==5.0.3
           - types-pyyaml==6.0.8
+          - types-requests==2.25.1
         args: [--ignore-missing-imports]

--- a/ckanext/dalrrd_emc_dcpr/get_releases.py
+++ b/ckanext/dalrrd_emc_dcpr/get_releases.py
@@ -1,0 +1,22 @@
+import requests
+import json
+
+username = "Mohab25"
+token = "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"
+
+res = requests.get(
+    "https://api.github.com/repos/kartoza/ckanext-dalrrd-emc-dcpr/tags",
+    auth=(username, token),
+)
+releases = json.loads(res.text)
+latest_releases_ob = {}
+for rel in releases:
+    if "rc" in rel.get("name"):
+        if "latest_release_candidate" not in latest_releases_ob:
+            latest_releases_ob["latest_release_candidate"] = rel.get("name")
+    else:
+        if "latest_release" not in latest_releases_ob:
+            latest_releases_ob["latest_release"] = rel.get("name")
+
+with open("releases.txt", "w") as f:
+    f.write(json.dumps(latest_releases_ob))

--- a/ckanext/dalrrd_emc_dcpr/helpers.py
+++ b/ckanext/dalrrd_emc_dcpr/helpers.py
@@ -4,7 +4,7 @@ import typing
 import datetime
 from urllib.parse import quote
 from html import escape as html_escape
-
+from pathlib import Path
 from shapely import geometry
 from ckan import model
 from ckan.plugins import toolkit
@@ -426,3 +426,37 @@ def get_maintenance_custom_other_field_data(data_dict):
 
 def get_today_date() -> str:
     return datetime.datetime.now().strftime("%Y-%m-%d")
+
+
+def get_current_release():
+    """
+    get releases to website footer,
+    the release depends on the environment,
+    if it's staging it uses v*.*.*-rc, rather
+    if it's production v.*.*.*
+    """
+    with open("releases.txt") as f:
+        releases = json.loads(f.read())
+        current_branch = _get_git_branch()
+        # this might change so main is release candidate
+        # and release branch is the latest release
+        if current_branch == "development":
+            return releases.get("latest_release_candidate")
+        elif current_branch == "main":
+            return releases.get("latest_release")
+        else:
+            return ""
+
+
+def _get_git_branch():
+    """
+    getting the current
+    branch name
+    """
+    head_dir = Path(__file__).parents[2] / ".git" / "HEAD"
+    with head_dir.open("r") as f:
+        content = f.read().splitlines()
+
+    for line in content:
+        if line[0:4] == "ref:":
+            return line.partition("refs/heads/")[2]

--- a/ckanext/dalrrd_emc_dcpr/helpers.py
+++ b/ckanext/dalrrd_emc_dcpr/helpers.py
@@ -435,7 +435,9 @@ def get_current_release():
     if it's staging it uses v*.*.*-rc, rather
     if it's production v.*.*.*
     """
-    with open("releases.txt") as f:
+    current_file_path = Path(__file__)
+    releases_file_path = current_file_path.parent.joinpath("releases.txt")
+    with open(releases_file_path) as f:
         releases = json.loads(f.read())
         current_branch = _get_git_branch()
         # this might change so main is release candidate

--- a/ckanext/dalrrd_emc_dcpr/plugins/emc_dcpr_plugin.py
+++ b/ckanext/dalrrd_emc_dcpr/plugins/emc_dcpr_plugin.py
@@ -348,6 +348,7 @@ class DalrrdEmcDcprPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
             "mod_scheming_flatten_subfield": helpers.mod_scheming_flatten_subfield,
             "get_today_date": helpers.get_today_date,
             "get_maintenance_custom_other_field_data": helpers.get_maintenance_custom_other_field_data,
+            "get_release": helpers.get_current_release,
         }
 
     def get_blueprint(self) -> typing.List[Blueprint]:

--- a/ckanext/dalrrd_emc_dcpr/releases.txt
+++ b/ckanext/dalrrd_emc_dcpr/releases.txt
@@ -1,0 +1,1 @@
+{"latest_release": "v.0.0.1", "latest_release_candidate": "v0.0.1-rc"}

--- a/ckanext/dalrrd_emc_dcpr/templates/footer.html
+++ b/ckanext/dalrrd_emc_dcpr/templates/footer.html
@@ -9,7 +9,7 @@
         <div class="footer-text">Copyright &copy; - 2022 SOUTH AFRICAN SPATIAL DATA INFRASTRUCTURE
             <div class="emc-current-version" style="float:right; margin-right:10px">
                 <!-- <div class="=footer-text">current staging version : RC0.1 {{ emc_version.git_sha }}</div> -->
-                <div class="=footer-text">current staging version :{{ get_release() }}</div>
+                <div class="=footer-text">current version :{{ h.get_release() }}</div>
             </div>
         </div>
         <div class="language">

--- a/ckanext/dalrrd_emc_dcpr/templates/footer.html
+++ b/ckanext/dalrrd_emc_dcpr/templates/footer.html
@@ -8,7 +8,8 @@
     <div class="content">
         <div class="footer-text">Copyright &copy; - 2022 SOUTH AFRICAN SPATIAL DATA INFRASTRUCTURE
             <div class="emc-current-version" style="float:right; margin-right:10px">
-                <div class="=footer-text">current staging version : RC0.1 {{ emc_version.git_sha }}</div>
+                <!-- <div class="=footer-text">current staging version : RC0.1 {{ emc_version.git_sha }}</div> -->
+                <div class="=footer-text">current staging version :{{ get_release() }}</div>
             </div>
         </div>
         <div class="language">


### PR DESCRIPTION
this get the current release tags (simver, and simver-rc) and place them in the footer based on the current branch, "main" shows the simver and development branch shows the version with rc at the end, this behavior is going to change once there is a production site so the "main" branch would show staging "rc" label, and the production site (branch name maybe decided later, releases ?) will show the simver (e.g. v0.0.1).
![current_version](https://user-images.githubusercontent.com/58084234/201499138-51105bd4-1324-403a-8b8e-c6061f0193d3.png)

![current_version-rc](https://user-images.githubusercontent.com/58084234/201499136-90746d17-22d0-44b4-84c5-45f51da5cd14.png)
