### PR TITLE
fixes with metadata records versioning

### DIFF
--- a/ckanext/dalrrd_emc_dcpr/logic/action/dataset_versioning_control.py
+++ b/ckanext/dalrrd_emc_dcpr/logic/action/dataset_versioning_control.py
@@ -43,6 +43,7 @@ def handle_versioning(context, data_dict):
             for _ in range(6)
         )
         update_dataset_title_and_url(new_version, generated_id, data_dict)
+        context["ignore_auth"] = True
         result = toolkit.get_action("package_create")(context, data_dict)
         flash_success("new version is created, updating the existing one !")
         return result

--- a/ckanext/dalrrd_emc_dcpr/logic/action/dataset_versioning_control.py
+++ b/ckanext/dalrrd_emc_dcpr/logic/action/dataset_versioning_control.py
@@ -32,6 +32,8 @@ def handle_versioning(context, data_dict):
             if k == "state":
                 if old_dataset[k] == "draft":
                     return data_dict
+            if k == "resources":
+                return data_dict
 
     new_version = data_dict.get("version")
     url = data_dict.get("name")


### PR DESCRIPTION
versioning once there is an update over a metadata record and create and record, changes in resources led to unexpected behaviors as adding or re-ordering resources is considered a trivial change that doesn't have to create a new version