### PR TITLE
fixes with showing dcpr requests in search page, remove legacy implem…

### DIFF
--- a/ckanext/dalrrd_emc_dcpr/templates/package/search.html
+++ b/ckanext/dalrrd_emc_dcpr/templates/package/search.html
@@ -34,8 +34,7 @@
 
 {% block primary_content %}
     {% block package_search_results_list %}
-    {% set dcpr_requests_approved_by_nsif = h.dcpr_requests_approved_by_nsif(request.path) %}
-        {{ h.snippet('snippets/package_list.html', packages=page.items+dcpr_requests_approved_by_nsif) }}
+        {{ h.snippet('snippets/package_list.html', packages=page.items) }}
     {% endblock %}
     {% block page_pagination %}
       {{ page.pager(q=q) }}


### PR DESCRIPTION
this is a fix to #408, previously we got all dcpr requests approved by nsif on search page, the latest implementation added by @Samweli was to create datasets from dcpr requests after approval and thus they to be showed in the search page.