### PR TITLE
add metatags for SEO issues #269

### DIFF
--- a/ckanext/dalrrd_emc_dcpr/helpers.py
+++ b/ckanext/dalrrd_emc_dcpr/helpers.py
@@ -584,3 +584,21 @@ def get_recent_news(number=5, exclude=None):
             break
 
     return new_list
+
+
+def get_seo_metatags(site_key):
+    """
+    get metatags value for SEO
+    """
+    data_dict = {
+        "site_author": toolkit.config.get(
+            "ckan.site_author",
+        ),
+        "site_description": toolkit.config.get(
+            "ckan.site_description",
+        ),
+        "site_keywords": toolkit.config.get(
+            "ckan.site_keywords",
+        ),
+    }
+    return data_dict[site_key]

--- a/ckanext/dalrrd_emc_dcpr/plugins/emc_dcpr_plugin.py
+++ b/ckanext/dalrrd_emc_dcpr/plugins/emc_dcpr_plugin.py
@@ -361,6 +361,7 @@ class DalrrdEmcDcprPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
             "get_dcpr_requests_awaiting_nsif_moderation_count": helpers.get_dcpr_requests_awaiting_nsif_moderation_count,
             "get_featured_datasets_count": helpers.get_featured_datasets_count,
             "get_user_name": helpers.get_user_name,
+            "get_seo_metatags": helpers.get_seo_metatags
         }
 
     def get_blueprint(self) -> typing.List[Blueprint]:

--- a/ckanext/dalrrd_emc_dcpr/plugins/emc_dcpr_plugin.py
+++ b/ckanext/dalrrd_emc_dcpr/plugins/emc_dcpr_plugin.py
@@ -361,11 +361,8 @@ class DalrrdEmcDcprPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
             "get_dcpr_requests_awaiting_nsif_moderation_count": helpers.get_dcpr_requests_awaiting_nsif_moderation_count,
             "get_featured_datasets_count": helpers.get_featured_datasets_count,
             "get_user_name": helpers.get_user_name,
-<<<<<<< HEAD
             "get_seo_metatags": helpers.get_seo_metatags,
-=======
             "get_datasets_thumbnail": helpers.get_datasets_thumbnail,
->>>>>>> upstream/development
         }
 
     def get_blueprint(self) -> typing.List[Blueprint]:

--- a/ckanext/dalrrd_emc_dcpr/plugins/emc_dcpr_plugin.py
+++ b/ckanext/dalrrd_emc_dcpr/plugins/emc_dcpr_plugin.py
@@ -361,7 +361,7 @@ class DalrrdEmcDcprPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
             "get_dcpr_requests_awaiting_nsif_moderation_count": helpers.get_dcpr_requests_awaiting_nsif_moderation_count,
             "get_featured_datasets_count": helpers.get_featured_datasets_count,
             "get_user_name": helpers.get_user_name,
-            "get_seo_metatags": helpers.get_seo_metatags
+            "get_seo_metatags": helpers.get_seo_metatags,
         }
 
     def get_blueprint(self) -> typing.List[Blueprint]:

--- a/ckanext/dalrrd_emc_dcpr/templates/base.html
+++ b/ckanext/dalrrd_emc_dcpr/templates/base.html
@@ -1,5 +1,13 @@
 {% ckan_extends %}
 
+{% block meta %}
+    {{ super() }}
+    <meta name="author" value="{{ g.site_author }}" />
+    <meta name="title" content="{{ g.site_title }}" />
+    <meta name="description" content="{{ g.site_description }}" />
+    <meta name="keywords" content="{{ g.site_keywords }}" />
+{% endblock %}
+
 {% block styles %}
 {#    {{ super() }}#}
     {% asset 'ckanext-dalrrdemcdcpr/ckan-base-css' %}

--- a/ckanext/dalrrd_emc_dcpr/templates/base.html
+++ b/ckanext/dalrrd_emc_dcpr/templates/base.html
@@ -2,10 +2,10 @@
 
 {% block meta %}
     {{ super() }}
-    <meta name="author" value="{{ g.site_author }}" />
     <meta name="title" content="{{ g.site_title }}" />
-    <meta name="description" content="{{ g.site_description }}" />
-    <meta name="keywords" content="{{ g.site_keywords }}" />
+    <meta name="author" value="{{ h.get_seo_metatags('site_author') }}" />
+    <meta name="description" content="{{ h.get_seo_metatags('site_description') }}" />
+    <meta name="keywords" content="{{ h.get_seo_metatags('site_keywords') }}" />
 {% endblock %}
 
 {% block styles %}

--- a/docker/ckan-dev-settings.ini
+++ b/docker/ckan-dev-settings.ini
@@ -180,12 +180,16 @@ ckan.harvest.mq.redis_db = 0
 
 ckan.site_title = SASDI EMC/DCPR
 ckan.site_logo = /images/Logo.png
-ckan.site_description =
+ckan.site_description = EMC/DCPR Description
 ckan.favicon = /images/favicon.ico
 ckan.gravatar_default = identicon
 ckan.preview.direct = png jpg gif
 ckan.preview.loadable = html htm rdf+xml owl+xml xml n3 n-triples turtle plain atom csv tsv rss txt json
 ckan.display_timezone = server
+
+## SEO Metatags Settings
+ckan.site_author = author_name
+ckan.site_keywords = EMC, DCPR, Electronic, Metadata, Catalogue, Data, Capture, Project, Register
 
 # package_hide_extras = for_search_index_only
 #package_edit_return_url = http://another.frontend/dataset/<NAME>


### PR DESCRIPTION
Issue #269

Metatags are attached on base.html. These metatags are examples of on-page SEO techniques.
