### PR TITLE
Autogenerate thumbnail based on metadata input #400 & #399

### DIFF
--- a/ckanext/dalrrd_emc_dcpr/helpers.py
+++ b/ckanext/dalrrd_emc_dcpr/helpers.py
@@ -282,8 +282,6 @@ def get_datasets_thumbnail(package):
                 wms_url = resource["url"]
                 parsed_url = dict(parse_qsl(urlparse(wms_url).query))
                 parsed_url["format"] = "image/png; mode=8bit"
-                parsed_url["width"] = "200"
-                parsed_url["height"] = "200"
                 data_thumbnail = "%s?%s" % (
                     wms_url.split("?")[0],
                     urlencode(parsed_url),

--- a/ckanext/dalrrd_emc_dcpr/helpers.py
+++ b/ckanext/dalrrd_emc_dcpr/helpers.py
@@ -3,7 +3,7 @@ import logging
 import typing
 import datetime
 import uuid
-from urllib.parse import quote
+from urllib.parse import quote, urlparse, parse_qsl, urlencode
 from html import escape as html_escape
 from pathlib import Path
 from shapely import geometry
@@ -265,6 +265,33 @@ def get_all_datasets_count(user_obj):
         data_dict={"q": "*:*", "include_private": True}
     )
     return result["count"]
+
+
+def get_datasets_thumbnail(package):
+    """
+    Generate thumbnails based on metadataset
+    https://github.com/kartoza/ckanext-dalrrd-emc-dcpr/issues/400
+    https://github.com/kartoza/ckanext-dalrrd-emc-dcpr/issues/399
+    """
+    if package["metadata_thumbnail"]:
+        data_thumbnail = package["metadata_thumbnail"]
+    else:
+        data_resource = package["resources"]
+        for resource in data_resource:
+            if resource["format"].lower() == "wms":
+                wms_url = resource["url"]
+                parsed_url = dict(parse_qsl(urlparse(wms_url).query))
+                parsed_url["format"] = "image/png; mode=8bit"
+                parsed_url["width"] = "200"
+                parsed_url["height"] = "200"
+                data_thumbnail = "%s?%s" % (
+                    wms_url.split("?")[0],
+                    urlencode(parsed_url),
+                )
+                break
+            else:
+                data_thumbnail = False
+    return data_thumbnail
 
 
 def _pad_geospatial_extent(extent: typing.Dict, padding: float) -> typing.Dict:

--- a/ckanext/dalrrd_emc_dcpr/plugins/emc_dcpr_plugin.py
+++ b/ckanext/dalrrd_emc_dcpr/plugins/emc_dcpr_plugin.py
@@ -361,6 +361,7 @@ class DalrrdEmcDcprPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
             "get_dcpr_requests_awaiting_nsif_moderation_count": helpers.get_dcpr_requests_awaiting_nsif_moderation_count,
             "get_featured_datasets_count": helpers.get_featured_datasets_count,
             "get_user_name": helpers.get_user_name,
+            "get_datasets_thumbnail": helpers.get_datasets_thumbnail,
         }
 
     def get_blueprint(self) -> typing.List[Blueprint]:

--- a/ckanext/dalrrd_emc_dcpr/scheming/dataset_schema.yaml
+++ b/ckanext/dalrrd_emc_dcpr/scheming/dataset_schema.yaml
@@ -768,7 +768,7 @@ dataset_fields:
     required: false
     form_placeholder: https://files.isric.org/public/thumbnails/afsis250m/clyppt.png
     help_text: >-
-      URL for a thumbnail previewing this metadata record which appears in the search page
+      URL for a thumbnail previewing this metadata record which appears in the search page. Use images with 1:1 ratio for better results
 
 
   - field_name: metadata_date_stamp

--- a/ckanext/dalrrd_emc_dcpr/templates/snippets/package_item.html
+++ b/ckanext/dalrrd_emc_dcpr/templates/snippets/package_item.html
@@ -13,7 +13,7 @@
       {% block content %}
           {% set date = package['metadata_modified'].split('T')[0] %}
           <div class="row dataset-row">
-          <div class="col-md-3 metadata-record-thumbnail" style="background-image: url('https://files.isric.org/public/thumbnails/afsis250m/clyppt.png');">
+          <div class="col-md-3 metadata-record-thumbnail" style="background-image: url('{{ h.get_datasets_thumbnail(package) }}');">
 
           </div>
         <div class="col-md-9 metadata-record-desc">

--- a/ckanext/dalrrd_emc_dcpr/templates/snippets/package_item.html
+++ b/ckanext/dalrrd_emc_dcpr/templates/snippets/package_item.html
@@ -13,7 +13,7 @@
       {% block content %}
           {% set date = package['metadata_modified'].split('T')[0] %}
           <div class="row dataset-row">
-          <div class="col-md-3 metadata-record-thumbnail" style="background-image: url('{{ h.get_datasets_thumbnail(package) }}');">
+          <div class="col-md-3 metadata-record-thumbnail" style="background-size: contain;background-image: url('{{ h.get_datasets_thumbnail(package) }}');">
 
           </div>
         <div class="col-md-9 metadata-record-desc">


### PR DESCRIPTION
This pull request fix Issue #399 & #400 

Thumbnails will be displayed based on metadata thumbnail input as we can see below:
![image](https://user-images.githubusercontent.com/7609337/210686906-1340c718-8c92-4b7d-99b0-cd85a81899ab.png)

![image](https://user-images.githubusercontent.com/7609337/210686970-3182b894-a87c-4909-9a46-d38b171b42f4.png)

If the metadata thumbnail input is unset. It will try to extract images from resource data with WMS format as thumbnail. Here is my WMS instance as data resource:
![image](https://user-images.githubusercontent.com/7609337/210687510-e492aba8-ff3a-468b-b442-14813ddc3395.png)

and it will be displayed as thumbnail : 

![image](https://user-images.githubusercontent.com/7609337/210687789-55ea6e9f-d623-46b0-90d0-3472695175c3.png)





