### PR TITLE
Remove note as alt on thumbnal img

### DIFF
--- a/ckanext/dalrrd_emc_dcpr/assets/css/dalrrd-emc-dcpr.css
+++ b/ckanext/dalrrd_emc_dcpr/assets/css/dalrrd-emc-dcpr.css
@@ -384,8 +384,15 @@ fieldset[disabled] .btn-default.focus {
 
 .dataset-heading a {
   color: #3A744E;
+  font-size: 14px;
   font-weight: 600;
   text-decoration: none;
+}
+
+.dataset-desc {
+  color: #484848;
+  font-size: 14px;
+  font-weight: 300;
 }
 
 .dataset-heading > a:hover, .dataset-heading > a:focus {
@@ -613,7 +620,7 @@ fieldset[disabled] .btn-default.focus {
 .sample-datasets {
   position: relative;
   background-color: #FFFFFF;
-  color: #3A744E;
+  color: #484848;
   margin-bottom: 20px;
 }
 

--- a/ckanext/dalrrd_emc_dcpr/templates/snippets/package_item.html
+++ b/ckanext/dalrrd_emc_dcpr/templates/snippets/package_item.html
@@ -14,7 +14,7 @@
           {% set date = package['metadata_modified'].split('T')[0] %}
           <div class="row dataset-row">
             <div class="col-sm-4 metadata-record-thumbnail">
-                <img src="{{ h.get_datasets_thumbnail(package) }}" alt="{{ notes }}" title="{{ title }}"></img>
+                <img src="{{ h.get_datasets_thumbnail(package) }}" alt="" title="{{ title }}">
             </div>
             <div class="col-sm-8 metadata-record-desc">
               <div class="dataset-content">


### PR DESCRIPTION
The package note is too long to be alt.  it caused this on the landing page 

![image](https://user-images.githubusercontent.com/12623986/212852792-d27338ff-df5e-4a6c-a1bf-dccd32da029b.png)
