### PR TITLE
fixes with user dashboard and space datasets

### DIFF
--- a/ckanext/dalrrd_emc_dcpr/helpers.py
+++ b/ckanext/dalrrd_emc_dcpr/helpers.py
@@ -20,6 +20,8 @@ from .constants import DCPRRequestStatus
 from .model.dcpr_request import DCPRRequest
 
 from ckan.common import c
+from ckan.lib.dictization.model_dictize import package_dictize
+from ckan.lib.dictization import table_dictize
 
 
 logger = logging.getLogger(__name__)
@@ -640,3 +642,26 @@ def get_year():
     footer
     """
     return datetime.datetime.now().year
+
+
+def get_user_dashboard_packages(user_id):
+    """
+    the current behavior displays
+    all the avialable datastes to the
+    user, we need only the datasets
+    created by the user
+    """
+    # q = f""" select package.*, key, value from package join package_extra on package_id=package.id where package.creator_user_id='{user_id}' """
+    # rows = model.Session.execute(q)
+    # packages = []
+    # for row in rows:
+    #     packages.append(dict(row))
+    # return packages
+    query = model.Session.query(model.Package).filter(
+        model.Package.creator_user_id == user_id
+    )
+    packages = [
+        package_dictize(package, context={"user": user_id, "model": model})
+        for package in query.all()
+    ]
+    return packages

--- a/ckanext/dalrrd_emc_dcpr/plugins/emc_dcpr_plugin.py
+++ b/ckanext/dalrrd_emc_dcpr/plugins/emc_dcpr_plugin.py
@@ -396,6 +396,7 @@ class DalrrdEmcDcprPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
             "get_seo_metatags": helpers.get_seo_metatags,
             "get_datasets_thumbnail": helpers.get_datasets_thumbnail,
             "get_year": helpers.get_year,
+            "get_user_dashboard_packages": helpers.get_user_dashboard_packages,
         }
 
     def get_blueprint(self) -> typing.List[Blueprint]:

--- a/ckanext/dalrrd_emc_dcpr/templates/snippets/package_item.html
+++ b/ckanext/dalrrd_emc_dcpr/templates/snippets/package_item.html
@@ -11,7 +11,8 @@
     {% else %}
       <li class="{{ item_class or "dataset-item" }}">
         {% block content %}
-          {% set date = package['metadata_modified'].split('T')[0] %}
+          {% set date_string = package['metadata_modified']|string %}
+          {% set date = date_string.split('T')[0] %}
           <div class="row dataset-row">
             <div class="col-sm-4 metadata-record-thumbnail">
                 <img src="{{ h.get_datasets_thumbnail(package) }}" alt="{{ notes }}" title="{{ title }}"></img>

--- a/ckanext/dalrrd_emc_dcpr/templates/user/dashboard_datasets.html
+++ b/ckanext/dalrrd_emc_dcpr/templates/user/dashboard_datasets.html
@@ -1,0 +1,17 @@
+{% ckan_extends %}
+{% set user_created_packages = h.get_user_dashboard_packages(c.userobj.id) %}
+
+
+{% block primary_content_inner %}
+
+  {% if user_created_packages|length>0 %}
+    {% snippet 'snippets/package_list.html', packages=user_created_packages %}
+  {% else %}
+    <p class="empty">
+      {{ _('You haven\'t created any datasets.') }}
+      {% if h.check_access('package_create') %}
+        {% link_for _('Create one now?'), named_route=dataset_type ~ '.new' %}
+      {% endif %}
+    </p>
+  {% endif %}
+{% endblock %}

--- a/ckanext/dalrrd_emc_dcpr/templates/user/read.html
+++ b/ckanext/dalrrd_emc_dcpr/templates/user/read.html
@@ -1,0 +1,22 @@
+{% ckan_extends %}
+{% block package_list %}
+{% set user_created_packages = h.get_user_dashboard_packages(c.userobj.id) %}
+
+{% if user_created_packages | length > 1 %}
+  {% snippet 'snippets/package_list.html', packages=user_created_packages %}
+{% else %}
+
+  {% if is_myself %}
+    <p class="empty">
+      {{ _('You haven\'t created any datasets.') }}
+      {% if h.check_access('package_create') %}
+        {% link_for _('Create one now?'), named_route='dataset.new' %}
+      {% endif %}
+    </p>
+  {% else %}
+    <p class="empty">
+      {{ _('User hasn\'t created any datasets.') }}
+    </p>
+  {% endif %}
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
the current behavior shows several  metadata records  on user's dashboard and space, only  metadata records created by the user should appear